### PR TITLE
bumping docker-mock

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dat-middleware": "~1.5.13",
     "debug": "~0.7.2",
     "docker-image-builder": "~0.2.0",
-    "docker-mock": "0.0.11",
+    "docker-mock": "~0.0.12",
     "dockerode": "~1.3.0",
     "dogerode": "0.0.3",
     "dogstatsyware": "0.0.1",


### PR DESCRIPTION
bumping docker-mock version. adds 'attach' functionality (but that is nocked out in the tests anyway, so this shouldn't have any effect off the bat)
