### PR TITLE
Fixing-build-file-rename

### DIFF
--- a/lib/models/mongo/infra-code-version.js
+++ b/lib/models/mongo/infra-code-version.js
@@ -9,6 +9,7 @@ var pick = require('101/pick');
 var last = require('101/last');
 var isFunction = require('101/is-function');
 var debug = require('debug')('runnable-api:infra-code-version:model');
+var regexpQuote = require('regexp-quote');
 
 var path = require('path');
 var join = path.join;
@@ -59,7 +60,7 @@ InfraCodeVersionSchema.statics.createCopyById = function (infraCodeVersionId, cb
  */
 InfraCodeVersionSchema.methods.findFs = function (path, cb) {
   var Key = join(this.context.toString(), 'source', path);
-  var regexp = new RegExp('^'+Key+'(\/)?$');
+  var regexp = new RegExp('^'+regexpQuote(Key)+'(\/)?$');
   InfraCodeVersion.findOne({
     _id: this._id
   }, {
@@ -72,6 +73,7 @@ InfraCodeVersionSchema.methods.findFs = function (path, cb) {
     cb(err, infraCodeVersion && infraCodeVersion.files[0]);
   });
 };
+
 /**
  * find infraCodeVersoin with a single dir
  * @param  {ObjectId}   id      infraCodeVersion id

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "primus": "2.3.0",
     "redis": "^0.8.3",
     "redis-types": "^0.2.0",
+    "regexp-quote": "0.0.0",
     "request": "^2.37.0",
     "rimraf": "^2.2.8",
     "rollbar": "^0.3.8",


### PR DESCRIPTION
This fixes the issue where the database would not return files or folders containing characters which needed to be escaped.  This fixes deleting and renaming files
