### PR TITLE
connect to mongo before running keygenerator

### DIFF
--- a/lib/key-generator.js
+++ b/lib/key-generator.js
@@ -4,14 +4,22 @@ var debug = require('debug')('runnable-api:deployKeyGenerator');
 require('loadenv')();
 var Keypair = require('models/mongo/keypair');
 var async = require('async');
+var mongoose = require('mongoose');
 
 module.exports.go = function () {
-  debug('keypair generator has started');
-  checkAndGenerateKeypairs(function (err) {
+  debug('keypair generator waiting for mongo');
+  mongoose.connect(process.env.MONGO, function (err) {
     if (err) {
-      console.error('something went wrong in the key generator', err);
+      console.error('keypair generator could not connect to mongo');
     } else {
-      setInterval(checkAndGenerateKeypairs, 60*1000);
+      debug('keypair generator has started');
+      checkAndGenerateKeypairs(function (err) {
+        if (err) {
+          console.error('something went wrong in the key generator', err);
+        } else {
+          setInterval(checkAndGenerateKeypairs, 60*1000);
+        }
+      });
     }
   });
 };


### PR DESCRIPTION
prevents .count() from hanging when the request is made from master
