### PR TITLE
Build stays on "building" status after failure

### DIFF
--- a/lib/models/mongo/context-version.js
+++ b/lib/models/mongo/context-version.js
@@ -402,6 +402,7 @@ ContextVersionSchema.methods.updateBuildError = function (err, cb) {
   }
   contextVersion.update({
     $set: {
+      'build.completed' : Date.now(),
       'build.error.message': err.message,
       'build.error.stack': err.stack,
       'build.log': log


### PR DESCRIPTION
setting completed on errorUpdate, which should tell the UI the builds have actually failed
