### PR TITLE
Cleaning Log Stream output

### DIFF
--- a/lib/socket/log-stream.js
+++ b/lib/socket/log-stream.js
@@ -51,7 +51,7 @@ function logHandler (socket, id, data) {
 function joinStreams(src, des) {
   src.on('data', function(data) {
     if (des.stream) {
-      des.write(dockerCleaner(data.toString()));
+      des.write(dockerCleaner(data).toString());
     }
   });
 }


### PR DESCRIPTION
Data should be cleaned before toString
