### PR TITLE
fixing-SAN-59

### DIFF
--- a/lib/models/mongo/context.js
+++ b/lib/models/mongo/context.js
@@ -23,10 +23,10 @@ ContextSchema.methods.isPublic = function (cb) {
   cb(err, this);
 };
 
-ContextSchema.statics.createBy = function (user, props, cb) {
+ContextSchema.statics.createBy = function (props, cb) {
   var context = new Context(props);
   context.set({
-    owner: props.owner || { github: user.accounts.github.id }
+    owner: props.owner
   });
   cb(null, context);
 };

--- a/lib/routes/contexts/index.js
+++ b/lib/routes/contexts/index.js
@@ -83,9 +83,16 @@ app.delete('/:id',
  *  @memberof module:rest/contexts */
 app.post('/',
   mw.body('name').require(),
-  // FIXME: only allow moderators to create source contexts
   mw.body('name', 'owner', 'isSource').pick(),
-  contexts.createBy('sessionUser', 'body'),
+  mw.body('owner.github').require()
+    .then(mw.body('owner.github').number())
+    .else(mw.body().set('owner.github', 'sessionUser.accounts.github.id')),
+  mw.body('isSource').require()
+    .then(me.isModerator) // Only Moderators should be able to create Source Contexts
+    .else(flow.or(
+      me.isOwnerOf('body'),
+      me.isModerator)),
+  contexts.createBy('body'),
   contexts.model.save(),
   mw.res.send(201, 'context'));
 


### PR DESCRIPTION
This fixes the issue where projects could not be created with the same name as projects of another entity on the user's account, as well as fixing the issue that caused only the creator of a Context to view files
