### PR TITLE
Since we know the req.build can be changed during this method, we need to return the correct build item back

### DIFF
--- a/lib/routes/projects/environments/builds.js
+++ b/lib/routes/projects/environments/builds.js
@@ -250,7 +250,7 @@ function buildVersionsAndTailLogs (req, res) {
   var build = req.build;
   var respondCounter = createCount(req.contextVersions.length, function () {
     // this error is already logged, always return 201
-    res.json(201, req.build);
+    res.json(201, build);
 
   });
   async.forEach(req.contextVersions, function (contextVersion, cb) {


### PR DESCRIPTION
Since we know the req.build can be changed during this method, we need to return the correct build item back
