### PR TITLE
locking version of github api

### DIFF
--- a/lib/routes/github/index.js
+++ b/lib/routes/github/index.js
@@ -113,6 +113,7 @@ function getETagFromRedis (req, res, next) {
 
 function proxyRequest (req, res) {
   req.headers.host = 'api.github.com:443';
+  req.headers.accept = 'application/vnd.github.v3+json';
   if (req.useETag) {
     req.headers['If-None-Match'] = req.useETag;
   }


### PR DESCRIPTION
this is to protect us from github changing the api out from underneath us
