### PR TITLE
adding sessionuser's token to the github cache digest

### DIFF
--- a/lib/routes/github/index.js
+++ b/lib/routes/github/index.js
@@ -19,6 +19,8 @@ var debug = require('debug')('runnable-api:routes:github');
 var qs = require('querystring');
 var xtend = require('xtend');
 var zlib = require('zlib');
+var keypather = require('keypather')();
+var clone = require('101/clone');
 
 var dogstatsd = require('models/datadog');
 
@@ -157,11 +159,13 @@ function proxyRequest (req, res) {
 }
 
 function hashKey (req) {
+  var q = req.query ? clone(req.query) : {};
+  q.accessToken = keypather.get(req, 'sessionUser.accounts.github.accessToken');
   return [
     'github-proxy:',
     req.method,
     req.url,
-    jsonHash.digest(req.query || {})
+    jsonHash.digest(q),
   ].join('');
 }
 


### PR DESCRIPTION
prevents other people from hitting other caches, and invalid etags being sent
(and more conditional requests to github missing)
