### PR TITLE
remove docker-stream-cleanser

### DIFF
--- a/lib/socket/build-stream.js
+++ b/lib/socket/build-stream.js
@@ -1,7 +1,6 @@
 'use strict';
 var debug = require('debug')('runnable-api:socket:build-stream');
 var Docker = require('models/apis/docker');
-var dockerCleaner = require('docker-stream-cleanser');
 var ContextVersion = require('models/mongo/context-version');
 var dogstatsd = require('../models/datadog');
 var baseDataName = 'api.socket.build';
@@ -151,7 +150,7 @@ function sendEndEvent(clientStream, socket, id, data, version) {
 function joinStreams(buildStream, clientStream) {
   buildStream.on('data', function(data) {
     if (clientStream.stream) {
-      clientStream.write(dockerCleaner(data).toString());
+      clientStream.write(data.toString());
     }
   });
 }

--- a/lib/socket/log-stream.js
+++ b/lib/socket/log-stream.js
@@ -1,7 +1,6 @@
 'use strict';
 var debug = require('debug')('runnable-api:socket:log-stream');
 var Docker = require('models/apis/docker');
-var dockerCleaner = require('docker-stream-cleanser');
 var dogstatsd = require('../models/datadog');
 var baseDataName = 'api.socket.log';
 
@@ -58,7 +57,7 @@ function logHandler (socket, id, data) {
 function joinStreams(src, des) {
   src.on('data', function(data) {
     if (des.stream) {
-      des.write(dockerCleaner(data).toString());
+      des.write(data.toString());
     }
   });
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "dat-middleware": "^1.9.0",
     "debug": "^1.0.2",
     "defaults": "^1.0.0",
-    "docker-stream-cleanser": "0.0.2",
     "dockerode": "^2.0.3",
     "dogerode": "0.0.3",
     "dogstatsyware": "0.0.1",


### PR DESCRIPTION
@Nathan219 all your fault :-1: 

we should do how dockerode does it
https://github.com/apocas/docker-modem/blob/master/lib/modem.js#L175

```
Modem.prototype.demuxStream = function(stream, stdout, stderr) {
  var header = null;

  stream.on('readable', function() {
    header = header || stream.read(8);
    while(header !== null) {
      var type = header.readUInt8(0);
      var payload = stream.read(header.readUInt32BE(4));
      if (payload === null) break;
      if(type == 2) {
        stderr.write(payload);
      } else {
        stdout.write(payload);
      }
      header = stream.read(8);
    }
  });
};
```
