### PR TITLE
SAN-185-ensure-runnable-model

### DIFF
--- a/lib/models/apis/runnable.js
+++ b/lib/models/apis/runnable.js
@@ -74,6 +74,7 @@ Runnable.prototype.destroyInstances = function (instances, cb) {
 Runnable.prototype.copyInstance = function (build, parentInstance, cb) {
   var body = {
     parentInstance: parentInstance.shortHash,
+    env: parentInstance.env,
     owner: parentInstance.owner,
     build: build.toJSON()._id
   };


### PR DESCRIPTION
Forgot to create a PR for this, apparently
These changes should help each method call create it's own express router
Without this, the express router would be shared and cause a lot of issues
