### PR TITLE
[DON'T PULL] unloop context version in build

### DIFF
--- a/lib/routes/builds.js
+++ b/lib/routes/builds.js
@@ -209,67 +209,61 @@ app.post('/builds/:id/actions/build',
   },
   builds.model.setInProgress('sessionUser'), // must be set before dedupe
   mw.req().set('attachCount', 0),
-  // mw.req('contextVersions').each(
-  //   function (contextVersion, req, eachReq, res, next) {
-  //     eachReq.req = req;
-  //     eachReq.contextVersion = contextVersion;
-  //     next();
-  //   },
-    mw.req().set('contextVersion', 'contextVersions[0]'),
-    flow.try(
-      mavis.create(),
-      mavis.model.findDock('container_build', 'contextVersion.dockerHost'),
-      mw.req().set('originalContextVersion', 'contextVersion'),
-      contextVersions.model.dedupe(),
-      builds.model.replaceContextVersion('originalContextVersion', 'contextVersion'),
-      // FIXME: handle errors - bc if buildStarted this falls through to catch
-      // then it will try to end an unstarted contextVersion
-      mw.req('contextVersion.build.started').require()
-        .then(
-          checkToRespond,
-          mw.req('contextVersion.build.completed').require()
-            .then(mw.req('contextVersion.build.error').require()
-              .then(builds.model.pushErroredContextVersion('contextVersion._id'))
-          ).else(pollMongo({
-              idPath: 'contextVersion._id',
-              database: require('models/mongo/context-version'),
-              successKeyPath: 'build.completed',
-              failureKeyPath: 'build.error',
-              failureCb: builds.model.pushErroredContextVersion('contextVersion._id')
-            }))
-      ).else(
-          contextVersions.model.setBuildStarted('sessionUser', 'mavisResult', 'body'),
-          docker.create('mavisResult'),
-          contextVersions.model.populate('infraCodeVersion'),
-          function (eachReq, res, next) {
-            var docker = eachReq.docker;
-            var sessionUser = eachReq.sessionUser;
-            var contextVersion = eachReq.contextVersion;
-            docker.createImageBuilderAndAttach(
-              sessionUser, contextVersion, function (err, container) {
-                if (err) { return next(err); }
-                eachReq.container = container;
-                next();
-              });
-          },
-          checkToRespond,
-          docker.model.startImageBuilderAndWait('sessionUser', 'contextVersion', 'container'),
-          contextVersions.model.setBuildCompleted('dockerResult'))
-    ).catch(
-      function (err, eachReq, res, next) {
-        eachReq.err = err;
-        logIfErrAndNext(next)(err);
-      },
-      function (eachReq, res, next) {
-        var count = createCount(2, next);
-        eachReq.contextVersion.updateBuildError(eachReq.err,
-          logIfErrAndNext(count.next.bind(count)));
-        eachReq.build.pushErroredContextVersion(eachReq.contextVersion._id,
-          logIfErrAndNext(count.next.bind(count)));
-      },
-      checkToRespond
-    ),
-  // ), // !each
+  // use the one, and only, context version!
+  mw.req().set('contextVersion', 'contextVersions[0]'),
+  flow.try(
+    mavis.create(),
+    mavis.model.findDock('container_build', 'contextVersion.dockerHost'),
+    mw.req().set('originalContextVersion', 'contextVersion'),
+    contextVersions.model.dedupe(),
+    builds.model.replaceContextVersion('originalContextVersion', 'contextVersion'),
+    // FIXME: handle errors - bc if buildStarted this falls through to catch
+    // then it will try to end an unstarted contextVersion
+    mw.req('contextVersion.build.started').require()
+      .then(
+        checkToRespond,
+        mw.req('contextVersion.build.completed').require()
+          .then(mw.req('contextVersion.build.error').require()
+            .then(builds.model.pushErroredContextVersion('contextVersion._id'))
+        ).else(pollMongo({
+            idPath: 'contextVersion._id',
+            database: require('models/mongo/context-version'),
+            successKeyPath: 'build.completed',
+            failureKeyPath: 'build.error',
+            failureCb: builds.model.pushErroredContextVersion('contextVersion._id')
+          }))
+    ).else(
+        contextVersions.model.setBuildStarted('sessionUser', 'mavisResult', 'body'),
+        docker.create('mavisResult'),
+        contextVersions.model.populate('infraCodeVersion'),
+        function (eachReq, res, next) {
+          var docker = eachReq.docker;
+          var sessionUser = eachReq.sessionUser;
+          var contextVersion = eachReq.contextVersion;
+          docker.createImageBuilderAndAttach(
+            sessionUser, contextVersion, function (err, container) {
+              if (err) { return next(err); }
+              eachReq.container = container;
+              next();
+            });
+        },
+        checkToRespond,
+        docker.model.startImageBuilderAndWait('sessionUser', 'contextVersion', 'container'),
+        contextVersions.model.setBuildCompleted('dockerResult'))
+  ).catch(
+    function (err, eachReq, res, next) {
+      eachReq.err = err;
+      logIfErrAndNext(next)(err);
+    },
+    function (eachReq, res, next) {
+      var count = createCount(2, next);
+      eachReq.contextVersion.updateBuildError(eachReq.err,
+        logIfErrAndNext(count.next.bind(count)));
+      eachReq.build.pushErroredContextVersion(eachReq.contextVersion._id,
+        logIfErrAndNext(count.next.bind(count)));
+    },
+    checkToRespond
+  ),
   builds.model.setCompleted(),
   builds.findById('build._id'),
   mw.req('build.successful').validate(validations.equals(true)).then(


### PR DESCRIPTION
no more loop over the context versions! no more weird req things. tested on io and it seemed to build just fine
