### PR TITLE
hack container files because it posts to /files on instance files

### DIFF
--- a/lib/routes/instances/containers/files.js
+++ b/lib/routes/instances/containers/files.js
@@ -8,7 +8,6 @@ var mongoMiddleware = require('middlewares/mongo');
 var instances = mongoMiddleware.instances;
 var me = require('middlewares/me');
 var checkFound = require('middlewares/check-found');
-var mw = require('dat-middleware');
 
 /*
   {fileObject} looks like this:
@@ -68,6 +67,16 @@ app.delete('/instances/:instanceId/containers/:containerId/files/*',
   containerFs.parseBody,
   containerFs.handleDel);
 
+/** stream files path
+ *  @returns {} empty object
+ *  @event POST /instance/:instanceId/containers/:containerId/files
+ *  @memberof module:rest/containers/files */
+app.post('/instances/:instanceId/containers/:containerId/files',
+  findContainer,
+  checkPermissons,
+  containerFs.parseParams,
+  containerFs.handleStream);
+
 /** update/create file or dir
  *  @returns {} empty object
  *  @event POST /instance/:instanceId/containers/:containerId/files
@@ -76,11 +85,8 @@ app.post('/instances/:instanceId/containers/:containerId/files/*',
   findContainer,
   checkPermissons,
   containerFs.parseParams,
-  mw.headers('content-type').matches(/multipart\/form-data.*/)
-    .then(containerFs.handleStream)
-    .else(containerFs.parseBody,
-          containerFs.handlePost)
-  );
+  containerFs.parseBody,
+  containerFs.handlePost);
 
 /** update/create file or dir
  *  @param file object with params to update.


### PR DESCRIPTION
I am not going to add the normal route for app.post('/instances/:instanceId/containers/:containerId/files',
since that is a frontend bug if they do that, we need to have some standards or our code will get more complex for no reason.
