### PR TITLE
add `username` to instance create responses

### DIFF
--- a/lib/routes/instances/index.js
+++ b/lib/routes/instances/index.js
@@ -190,6 +190,7 @@ app.post('/instances/',
       createAllContainers) // this contains an instances.model.save
     .else(
       instances.model.save()),
+  instances.model.getGithubUsername('sessionUser'),
   mw.res.send(201, 'instance'));
 
 /** Get in a instance

--- a/test/actions-github.js
+++ b/test/actions-github.js
@@ -311,6 +311,8 @@ describe('Github', function () {
           var options = hooks(ctx.contextVersion.json()).push;
           var username = options.json.repository.owner.name;
           var reponame = options.json.repository.name;
+          require('./fixtures/mocks/github/user')(ctx.user);
+          require('./fixtures/mocks/github/user')(ctx.user);
           require('./fixtures/mocks/github/repos-username-repo')(ctx.user, reponame);
           require('./fixtures/mocks/github/repos-hooks-get')(username, reponame);
           require('./fixtures/mocks/github/repos-hooks-post')(username, reponame);

--- a/test/bdd-deploy-instance.js
+++ b/test/bdd-deploy-instance.js
@@ -302,6 +302,7 @@ describe('BDD Create Build and Deploy Instance', function () {
           contents.fetch(function (err) {
             if (err) { return cb(err); }
             var dockerfile = find(contents.models, hasKeypaths({ 'attrs.name': 'Dockerfile' }));
+            require('./fixtures/mocks/s3/put-object')(ctx.context.id(), '/Dockerfile');
             dockerfile.update({
               json: {
                 body: 'FROM dockerfile/nodejs'

--- a/test/contexts-id-versions.js
+++ b/test/contexts-id-versions.js
@@ -125,6 +125,7 @@ describe('Versions - /contexts/:contextid/versions', function () {
     });
     describe('multiple versions', function () {
       beforeEach(function (done) {
+        require('./fixtures/mocks/s3/put-object')(ctx.context.id(), '/');
         ctx.contextVersion2 = ctx.context.createVersion(done);
       });
       it('should return all of them', function (done) {

--- a/test/fixtures/multi-factory.js
+++ b/test/fixtures/multi-factory.js
@@ -202,6 +202,7 @@ module.exports = {
       if (buildOwnerId) {
         require('./mocks/github/user-orgs')(buildOwnerId, 'Runnable');
         require('./mocks/github/user-orgs')(buildOwnerId, 'Runnable');
+        require('./mocks/github/user-orgs')(buildOwnerId, 'Runnable');
       } else {
         require('./mocks/github/user')(user);
       }

--- a/test/instances-id-actions.js
+++ b/test/instances-id-actions.js
@@ -30,6 +30,7 @@ describe('Instance - /instances/:id/actions', function () {
       ctx.build = build;
       ctx.user = user;
       require('./fixtures/mocks/github/user')(ctx.user);
+      require('./fixtures/mocks/github/user')(ctx.user);
       done();
     });
   });
@@ -39,6 +40,7 @@ describe('Instance - /instances/:id/actions', function () {
     });
     it('should start all containers', function (done) {
       var expected = ctx.instance.json();
+      delete expected.owner.username; // don't expect this here
       // FIXME: add some better checks here like State.StartedAt
       delete expected.containers;
       delete expected.__v;
@@ -83,6 +85,7 @@ describe('Instance - /instances/:id/actions', function () {
   describe('STOP', function () {
     it('should stop all containers', function (done) {
       var expected = ctx.instance.json();
+      delete expected.owner.username; // don't expect this in this case
       // FIXME: add some better checks here like State.FinishedAt
       delete expected.containers;
       delete expected.__v;
@@ -93,6 +96,7 @@ describe('Instance - /instances/:id/actions', function () {
 
     it('should not stop an already stopped container', function (done) {
       var expected = ctx.instance.json();
+      delete expected.owner.username; // don't expect this in this case
       // FIXME: add some better checks here like State.FinishedAt
       delete expected.containers;
       delete expected.__v;
@@ -158,7 +162,8 @@ describe('Instance - /instances/:id/actions', function () {
           name: exists,
           public: exists,
           createdBy: { github: ctx.user.json().accounts.github.id },
-          owner: { github: ctx.user.json().accounts.github.id },
+          owner: { github: ctx.user.json().accounts.github.id,
+                   username: ctx.user.json().accounts.github.username },
           parent: ctx.instance.id(),
           'build': ctx.build.id(),
           containers: exists
@@ -176,7 +181,8 @@ describe('Instance - /instances/:id/actions', function () {
           name: exists,
           public: exists,
           createdBy: { github: ctx.user.json().accounts.github.id },
-          owner: { github: ctx.user.json().accounts.github.id },
+          owner: { github: ctx.user.json().accounts.github.id,
+                   username: ctx.user.json().accounts.github.username },
           parent: ctx.instance.id(),
           'build': ctx.build.id(),
           containers: exists,
@@ -213,6 +219,7 @@ describe('Instance - /instances/:id/actions', function () {
         require('./fixtures/mocks/github/user-orgs')(ctx.orgId, 'Runnable');
         require('./fixtures/mocks/github/user-orgs')(ctx.orgId, 'Runnable');
         require('./fixtures/mocks/github/user-orgs')(ctx.orgId, 'Runnable');
+        require('./fixtures/mocks/github/user-orgs')(ctx.orgId, 'Runnable');
         ctx.user.copyInstance(ctx.instance.id(), expects.success(201, expected, done));
       });
       describe('Same org, different user', function () {
@@ -221,6 +228,7 @@ describe('Instance - /instances/:id/actions', function () {
           ctx.nonOwner = multi.createUser(done);
         });
         beforeEach(function (done) {
+          require('./fixtures/mocks/github/user-orgs')(ctx.orgId, 'Runnable');
           require('./fixtures/mocks/github/user-orgs')(ctx.orgId, 'Runnable');
           require('./fixtures/mocks/github/user-orgs')(ctx.orgId, 'Runnable');
           require('./fixtures/mocks/github/user-orgs')(ctx.orgId, 'Runnable');
@@ -237,6 +245,7 @@ describe('Instance - /instances/:id/actions', function () {
             build: ctx.build.id(),
             containers: exists
           };
+          require('./fixtures/mocks/github/user-orgs')(ctx.orgId, 'Runnable');
           require('./fixtures/mocks/github/user-orgs')(ctx.orgId, 'Runnable');
           require('./fixtures/mocks/github/user-orgs')(ctx.orgId, 'Runnable');
           require('./fixtures/mocks/github/user-orgs')(ctx.orgId, 'Runnable');
@@ -264,7 +273,8 @@ describe('Instance - /instances/:id/actions', function () {
             name: exists,
             public: exists,
             createdBy: { github: ctx.user.json().accounts.github.id },
-            owner: { github: ctx.user.json().accounts.github.id },
+            owner: { github: ctx.user.json().accounts.github.id,
+                     username: ctx.user.json().accounts.github.username },
             parent: ctx.instance.id(),
             'build': ctx.build.id(),
             containers: exists

--- a/test/instances-id.js
+++ b/test/instances-id.js
@@ -69,6 +69,7 @@ describe('Instance - /instances/:id', function () {
       ctx.cv = mdlArray[0];
       ctx.context = mdlArray[1];
       ctx.srcArray = srcArray;
+      require('./fixtures/mocks/github/user')(ctx.user);
       done();
     });
   });

--- a/test/instances.js
+++ b/test/instances.js
@@ -64,10 +64,12 @@ describe('Instances - /instances', function () {
             build: ctx.build.id(),
             name: exists,
             'owner.github': ctx.user.attrs.accounts.github.id,
+            'owner.username': ctx.user.attrs.accounts.github.username,
             contextVersions: exists,
             'contextVersions[0]._id': ctx.cv.id(),
             'contextVersions[0].appCodeVersions[0]': ctx.cv.attrs.appCodeVersions[0]
           };
+          require('./fixtures/mocks/github/user')(ctx.user);
           require('./fixtures/mocks/docker/container-id-attach')();
           require('./fixtures/mocks/github/repos-username-repo-branches-branch')(ctx.cv);
           ctx.build.build({ message: uuid() }, function (err) {
@@ -167,6 +169,7 @@ describe('Instances - /instances', function () {
           };
           require('./fixtures/mocks/github/user-orgs')(ctx.orgId, 'Runnable');
           require('./fixtures/mocks/github/user-orgs')(ctx.orgId, 'Runnable');
+          require('./fixtures/mocks/github/user-orgs')(ctx.orgId, 'Runnable');
           require('./fixtures/mocks/github/user')(ctx.user);
           require('./fixtures/mocks/docker/container-id-attach')();
           require('./fixtures/mocks/github/repos-username-repo-branches-branch')(ctx.cv);
@@ -229,6 +232,7 @@ describe('Instances - /instances', function () {
             name: exists,
             _id: exists
           };
+          require('./fixtures/mocks/github/user')(ctx.user);
           var instance = ctx.user.createInstance(json,
             expects.success(201, expected, function (err, instanceData) {
               if (err) { return done(err); }
@@ -246,12 +250,14 @@ describe('Instances - /instances', function () {
           var expected = {
             _id: exists,
             name: json.name,
-            owner: { github: ctx.user.json().accounts.github.id },
+            owner: { github: ctx.user.json().accounts.github.id,
+                     username: ctx.user.json().accounts.github.username },
             public: false,
             build: ctx.build.id(),
             containers: exists,
             'containers[0]': exists
           };
+          require('./fixtures/mocks/github/user')(ctx.user);
           var instance = ctx.user.createInstance(json,
             expects.success(201, expected, function (err) {
               if (err) { return done(err); }
@@ -276,12 +282,14 @@ describe('Instances - /instances', function () {
               _id: exists,
               name: json.name,
               env: json.env,
-              owner: { github: ctx.user.json().accounts.github.id },
+              owner: { github: ctx.user.json().accounts.github.id,
+                       username: ctx.user.json().accounts.github.username },
               public: false,
               build: ctx.build.id(),
               containers: exists,
               'containers[0]': exists
             };
+            require('./fixtures/mocks/github/user')(ctx.user);
             ctx.user.createInstance(json,
               expects.success(201, expected, done));
           });
@@ -293,6 +301,7 @@ describe('Instances - /instances', function () {
                 iCauseError: true
               }]
             };
+            require('./fixtures/mocks/github/user')(ctx.user);
             ctx.user.createInstance(json,
               expects.errorStatus(400, /should be an array of strings/, done));
           });
@@ -305,6 +314,7 @@ describe('Instances - /instances', function () {
                 '$@#4123TWO=2'
               ]
             };
+            require('./fixtures/mocks/github/user')(ctx.user);
             ctx.user.createInstance(json,
               expects.errorStatus(400, /should match/, done));
           });
@@ -324,12 +334,14 @@ describe('Instances - /instances', function () {
             var expected = {
               _id: exists,
               name: 'Instance1',
-              owner: { github: ctx.user.json().accounts.github.id },
+              owner: { github: ctx.user.json().accounts.github.id,
+                       username: ctx.user.json().accounts.github.username },
               public: false,
               build: ctx.build.id(),
               containers: exists,
               shortHash: exists
             };
+            require('./fixtures/mocks/github/user')(ctx.user);
             require('./fixtures/mocks/github/user')(ctx.user);
             ctx.user.createInstance(json, expects.success(201, expected, function (err, body1) {
               if (err) { return done(err); }
@@ -339,12 +351,14 @@ describe('Instances - /instances', function () {
                 return true;
               };
               require('./fixtures/mocks/github/user')(ctx.user);
+              require('./fixtures/mocks/github/user')(ctx.user);
               ctx.user.createInstance(json, expects.success(201, expected, function (err, body2) {
                 if (err) { return done(err); }
                 var expected2 = {
                   _id: exists,
                   name: 'Instance1',
-                  owner: { github: ctx.user2.json().accounts.github.id },
+                  owner: { github: ctx.user2.json().accounts.github.id,
+                           username: ctx.user2.json().accounts.github.username },
                   public: false,
                   build: ctx.build2.id(),
                   containers: exists,
@@ -358,6 +372,7 @@ describe('Instances - /instances', function () {
                 var json2 = {
                   build: ctx.build2.id()
                 };
+                require('./fixtures/mocks/github/user')(ctx.user2);
                 require('./fixtures/mocks/github/user')(ctx.user2);
                 ctx.user2.createInstance(json2, expects.success(201, expected2, done));
               }));
@@ -407,13 +422,15 @@ describe('Instances - /instances', function () {
         var expected = {
           _id: exists,
           name: 'Instance2',
-          owner: { github: ctx.user.json().accounts.github.id },
+          owner: { github: ctx.user.json().accounts.github.id,
+                   username: ctx.user.json().accounts.github.username },
           public: false,
           build: ctx.build.id(),
           containers: exists,
           parent: ctx.instance.id(),
           shortHash: exists
         };
+        require('./fixtures/mocks/github/user')(ctx.user);
         require('./fixtures/mocks/github/user')(ctx.user);
         ctx.user.createInstance(json, expects.success(201, expected, done));
       });
@@ -422,6 +439,8 @@ describe('Instances - /instances', function () {
 
   describe('GET', function() {
     beforeEach(function (done) {
+      require('./fixtures/mocks/github/user')(ctx.user);
+      require('./fixtures/mocks/github/user')(ctx.user2);
       multi.createInstance(function (err, instance, build, user) {
         if (err) { return done(err); }
         ctx.instance = instance;
@@ -534,6 +553,7 @@ describe('Instances - /instances', function () {
         require('./fixtures/mocks/github/user')(ctx.user);
         ctx.instance.update({ name: 'InstanceNumber1' }, function (err) {
           if (err) { return done(err); }
+          require('./fixtures/mocks/github/user')(ctx.user);
           require('./fixtures/mocks/github/user')(ctx.user);
           ctx.instance3 = ctx.user.createInstance({
             name: 'InstanceNumber3',
@@ -651,6 +671,7 @@ describe('Instances - /instances', function () {
         expected[0]['owner.username'] = ctx.orgName;
         expected[0]['owner.github'] = ctx.orgId;
         require('./fixtures/mocks/github/users-username')(ctx.orgId, ctx.orgName);
+        require('./fixtures/mocks/github/user-orgs')(ctx.orgId, ctx.orgName);
         require('./fixtures/mocks/github/user-orgs')(ctx.orgId, ctx.orgName);
         require('./fixtures/mocks/github/user-orgs')(ctx.orgId, ctx.orgName);
         ctx.user.fetchInstances(query, expects.success(200, expected, done));


### PR DESCRIPTION
- added github username to the POST response
- fixed all the tests for this new field
- unexpectedly fixed a bunch of other things that were broken if one was truly
  offline and running the tests
