### PR TITLE
Adding sanity check to docker response

### DIFF
--- a/lib/models/apis/docker.js
+++ b/lib/models/apis/docker.js
@@ -180,7 +180,7 @@ Docker.prototype.startImageBuilderAndWait = function (sessionUser, version, cont
           }
           var match = successRe.exec(buildLogData);
           var buildFailed = !match || !match[1];
-          if (buildFailed || res.StatusCode) {
+          if (buildFailed || (res && res.StatusCode)) {
             debug('build failed - ', res, buildLogData);
             cb(Boom.badRequest('Build Failed: Dockerfile error code: ' + res.StatusCode,
               { docker: {


### PR DESCRIPTION
If res is null here (which shouldn't happen very frequently), it could break everything.  Adding sanity check
