### PR TITLE
Remove project refs from the tests

### DIFF
--- a/test/build-stream.js
+++ b/test/build-stream.js
@@ -22,7 +22,7 @@ var primusClient = Primus.createSocket({
 
 var ctx = {};
 
-describe('Build Stream - /projects/:id/environments/:id/builds/:id/build', function() {
+describe('Build Stream', function() {
   ctx = {};
 
   before(api.start.bind(ctx));

--- a/test/contexts-id-versions-id-files-id.js
+++ b/test/contexts-id-versions-id-files-id.js
@@ -34,9 +34,6 @@ describe('Version File - /contexts/:contextid/versions/:id/files/:id', function 
     multi.createContextVersion(function (err, contextVersion, context, build, env, project, user, array){
       if (err) { return done(err); }
       ctx.build = build;
-      ctx.env = env;
-      ctx.project = project;
-      ctx.user = user;
       ctx.contextVersion = contextVersion;
       ctx.context = context;
       ctx.sourceContextVersion = array[0];

--- a/test/contexts-id-versions-id-files-id/patch/400.js
+++ b/test/contexts-id-versions-id-files-id/patch/400.js
@@ -31,8 +31,6 @@ describe('400 PATCH /contexts/:contextid/versions/:id/files/:id', function () {
     multi.createContextVersion(function (err, contextVersion, context, build, env, project, user){
       if (err) { return done(err); }
       ctx.build = build;
-      ctx.env = env;
-      ctx.project = project;
       ctx.user = user;
       ctx.contextVersion = contextVersion;
       ctx.context = context;
@@ -75,7 +73,7 @@ describe('400 PATCH /contexts/:contextid/versions/:id/files/:id', function () {
       dockerfile.update({json: body}, cb);
     });
 
-    
+
   });
-  
+
 });

--- a/test/contexts-id-versions-id-files/post/400.js
+++ b/test/contexts-id-versions-id-files/post/400.js
@@ -27,12 +27,8 @@ describe('400 POST /contexts/:contextid/versions/:id/files', function () {
   var dirPathName = 'dir[]()';
 
   beforeEach(function (done) {
-    multi.createContextVersion(function (err, contextVersion, context, build, env, project, user){
+    multi.createContextVersion(function (err, contextVersion, context){
       if (err) { return done(err); }
-      ctx.build = build;
-      ctx.env = env;
-      ctx.project = project;
-      ctx.user = user;
       ctx.contextVersion = contextVersion;
       ctx.context = context;
       require('../../fixtures/mocks/s3/get-object')(ctx.context.id(), '/');
@@ -83,7 +79,7 @@ describe('400 POST /contexts/:contextid/versions/:id/files', function () {
       ctx.contextVersion.rootDir.contents.create({json: body}, cb);
     });
 
-    
+
   });
-  
+
 });

--- a/test/fixtures/multi-factory.js
+++ b/test/fixtures/multi-factory.js
@@ -238,10 +238,10 @@ module.exports = {
   },
   createContainer: function (cb) {
     debug('createContainer', formatArgs(arguments));
-    this.createInstance(function (err, instance, build, env, project, user, modelsArray, srcArr) {
+    this.createInstance(function (err, instance, build, user, modelsArray, srcArr) {
       if (err) { return cb(err); }
       var container = instance.newContainer(instance.json().containers[0]);
-      cb(err, container, instance, build, env, project, user, modelsArray, srcArr);
+      cb(err, container, instance, build, user, modelsArray, srcArr);
     });
   },
 


### PR DESCRIPTION
We had few `project` and `env` references in the tests. They were not used.
