### PR TITLE
Use flushdb for removing all keys from redis

### DIFF
--- a/unit/active-api.js
+++ b/unit/active-api.js
@@ -5,7 +5,7 @@ var it = Lab.test;
 var after = Lab.after;
 var before = Lab.before;
 var expect = Lab.expect;
-var redisCleaner = require('../test/fixtures/redis-cleaner');
+var redis = require('models/redis');
 var activeApi = require('models/redis/active-api');
 
 require('loadenv')();
@@ -13,8 +13,8 @@ require('loadenv')();
 describe('Active API', function () {
   var ctx = {};
   describe('isMe', function () {
-    before(redisCleaner.clean('*'));
-    after(redisCleaner.clean('*'));
+    before(redis.flushdb.bind(redis));
+    after(redis.flushdb.bind(redis));
 
     it('should return false if setAsMe was never called', function (done) {
       activeApi.isMe(function (err, isActive) {
@@ -27,8 +27,8 @@ describe('Active API', function () {
   });
 
   describe('setAsMe', function () {
-    before(redisCleaner.clean('*'));
-    after(redisCleaner.clean('*'));
+    before(redis.flushdb.bind(redis));
+    after(redis.flushdb.bind(redis));
 
     before(function (done) {
       ctx.originUUID = process.env.UUID;

--- a/unit/docker-events.js
+++ b/unit/docker-events.js
@@ -6,12 +6,12 @@ var after = Lab.after;
 var before = Lab.before;
 var beforeEach = Lab.beforeEach;
 var afterEach = Lab.afterEach;
+var redis = require('models/redis');
 var pubsub = require('models/redis/pubsub');
 var error = require('error');
 var dockerEvents = require('models/events/docker');
 var events = require('models/events/index');
 var expect = Lab.expect;
-var redisCleaner = require('../test/fixtures/redis-cleaner');
 var createCount = require('callback-count');
 var uuid = require('uuid');
 var activeApi = require('models/redis/active-api');
@@ -22,8 +22,8 @@ describe('Docker Events', function () {
   var ctx = {};
 
   describe('handleDie', function () {
-    before(redisCleaner.clean('*'));
-    after(redisCleaner.clean('*'));
+    before(redis.flushdb.bind(redis));
+    after(redis.flushdb.bind(redis));
     afterEach(function (done) {
       dockerEvents.close(done);
     });
@@ -146,8 +146,8 @@ describe('Docker Events', function () {
   describe('events wrapper', function () {
 
     describe('listen', function () {
-      before(redisCleaner.clean('*'));
-      after(redisCleaner.clean('*'));
+      before(redis.flushdb.bind(redis));
+      after(redis.flushdb.bind(redis));
       afterEach(events.close.bind(events));
 
       it('should start listening and callback', function (done) {
@@ -182,8 +182,8 @@ describe('Docker Events', function () {
 
 
   describe('listen', function () {
-    before(redisCleaner.clean('*'));
-    after(redisCleaner.clean('*'));
+    before(redis.flushdb.bind(redis));
+    after(redis.flushdb.bind(redis));
     afterEach(dockerEvents.close.bind(dockerEvents));
 
 
@@ -208,8 +208,8 @@ describe('Docker Events', function () {
   });
 
   describe('event lock', function () {
-    before(redisCleaner.clean('*'));
-    after(redisCleaner.clean('*'));
+    before(redis.flushdb.bind(redis).bind(redis));
+    after(redis.flushdb.bind(redis));
     before(function (done) {
       ctx.origHandleDieGetEventLock = dockerEvents.getEventLock;
       done();

--- a/unit/redis-mutex.js
+++ b/unit/redis-mutex.js
@@ -5,13 +5,13 @@ var expect = Lab.expect;
 var before = Lab.before;
 var after = Lab.after;
 var createCount = require('callback-count');
-var redisCleaner = require('../test/fixtures/redis-cleaner');
 var RedisMutex = require('models/redis/mutex');
+var redis = require('models/redis');
 
 
 describe('RedisMutex', function () {
-  before(redisCleaner.clean('*'));
-  after(redisCleaner.clean('*'));
+  before(redis.flushdb.bind(redis));
+  after(redis.flushdb.bind(redis));
 
   var ctx = {};
 


### PR DESCRIPTION
Use redis `flushdb` command in the unit tests.
