### PR TITLE
add wait back in

### DIFF
--- a/lib/models/apis/docker.js
+++ b/lib/models/apis/docker.js
@@ -178,10 +178,10 @@ Docker.prototype.startImageBuilderAndWait = function (sessionUser, version, cont
     debug('container created - ', 'err:', err);
     if (err) { return cb(err); } // already a boom error
     container.wait(function (err, res) {
-    if (err) {
-      return self.handleErr(cb, 'docker wait failed', { containerId: container.Id })(err);
-    }
-    container.logs({
+      if (err) {
+        return self.handleErr(cb, 'docker wait failed', { containerId: container.Id })(err);
+      }
+      container.logs({
         follow: false,
         stdout: true,
         stderr: true


### PR DESCRIPTION
we are seeing logs are not closing therefore causing builds to not end. 
adding this back in until we use events from docker listener for build end events.
