### PR TITLE
add hsts to ignore from github res

### DIFF
--- a/lib/routes/github/index.js
+++ b/lib/routes/github/index.js
@@ -26,12 +26,13 @@ var corsHeaders = [
   'access-control-allow-credentials',
   'access-control-allow-headers',
   'access-control-expose-headers',
-  'access-control-max-age'
+  'access-control-max-age',
+  'strict-transport-security'
 ];
 var cacheOmitHeaders = [
   'date',
   'x-ratelimit-reset',
-  'x-served-by',
+  'x-served-by'
 ].concat(corsHeaders);
 
 var proxy = httpProxy.createProxy({


### PR DESCRIPTION
so we don't have browsers forcing https pre-emptivly
