### PR TITLE
force sauron attach and detach

### DIFF
--- a/lib/models/apis/sauron.js
+++ b/lib/models/apis/sauron.js
@@ -157,7 +157,10 @@ Sauron.prototype.attachHostToContainer =
       return cb(new Error('Host must be provided (container host) it cannot be random'));
     }
     var url = ['networks', networkIp, 'hosts', hostIp, 'actions/attach'];
-    this.put(url, {json:{ containerId: containerId }}, this.handleResErr(function (err) {
+    this.put(url, {json: {
+      containerId: containerId,
+      force: true
+    }}, this.handleResErr(function (err) {
       if (err &&
           !errorIs.containerNotRunning(err) &&
           !errorIs.containerDied(err) &&
@@ -179,7 +182,10 @@ Sauron.prototype.detachHostFromContainer = function (networkIp, hostIp, containe
     return cb(new Error('Host must be provided (container host) it cannot be random'));
   }
   var url = ['networks', networkIp, 'hosts', hostIp, 'actions/detach'];
-  this.put(url, {json:{ containerId: containerId }}, this.handleResErr(function (err) {
+  this.put(url, {json:{
+    containerId: containerId,
+    force: true
+  }}, this.handleResErr(function (err) {
     if (err &&
         !errorIs.containerNotRunning(err) &&
         !errorIs.containerDied(err) &&


### PR DESCRIPTION
always force at/detach for sauron. this ignores host at/detach issues due to incorrect mappings.

this issue happens when the old container death does not get handled before new container create.
one possible side effect is container to container communication might be flaky, but will confirm this is not the case on staging
