### PR TITLE
Fix bug with pushing empty branch with no commits

### DIFF
--- a/lib/notifications/slack.js
+++ b/lib/notifications/slack.js
@@ -143,7 +143,7 @@ Slack.prototype._createSlackLink = function (url, title) {
   return '<' + url + '|' + title + '>';
 };
 
-// Prepare array of commits based on git hood info
+// Prepare array of commits based on github hook info
 Slack.prototype._getCommits = function (gitInfo) {
   var commits = gitInfo.commitLog || [];
   if (commits.length === 0) {

--- a/unit/slack.js
+++ b/unit/slack.js
@@ -121,12 +121,6 @@ describe('Slack', function () {
         message: 'init & commit & push long test \n next line \n 3d line',
         url: 'https://github.com/CodeNow/api/commit/a240edf982d467201845b3bf10ccbe16f6049ea9'
       };
-      var commit2 = {
-        id: 'a240edf982d467201845b3bf10ccbe16f6049ea9',
-        author: {
-          username: 'podviaznikov'
-        }
-      };
       var gitInfo = {
         branch: 'feature-1',
         headCommit: headCommit,


### PR DESCRIPTION
There was error while trying to send slack message: because previously notification code expected non-empty array of commits (which is not the case with pushing new branch without commits).
