### PR TITLE
SAN 1277 - Enable the UI to store the previous org and instance location that was viewed by the user

### DIFF
--- a/lib/models/mongo/schemas/user.js
+++ b/lib/models/mongo/schemas/user.js
@@ -117,7 +117,9 @@ var UserSchema = module.exports = new Schema({
     type: {
       uiState: {
         type: {
-          shownCoachMarks: Mixed
+          shownCoachMarks: Mixed,
+          previousLocation: Mixed
+
         }
       }
     },

--- a/lib/routes/users/index.js
+++ b/lib/routes/users/index.js
@@ -42,7 +42,9 @@ var updateUser = series(
     'userOptions.uiState.shownCoachMarks.editButton',
     'userOptions.uiState.shownCoachMarks.explorer',
     'userOptions.uiState.shownCoachMarks.repoList',
-    'userOptions.uiState.shownCoachMarks.boxName'
+    'userOptions.uiState.shownCoachMarks.boxName',
+    'userOptions.uiState.previousLocation.org',
+    'userOptions.uiState.previousLocation.instance'
   ).pick(),
   mw.body({
     or: [
@@ -55,7 +57,9 @@ var updateUser = series(
       '["userOptions.uiState.shownCoachMarks.boxName"]',
       '["userOptions.uiState.shownCoachMarks.editButton"]',
       '["userOptions.uiState.shownCoachMarks.explorer"]',
-      '["userOptions.uiState.shownCoachMarks.repoList"]'
+      '["userOptions.uiState.shownCoachMarks.repoList"]',
+      '["userOptions.uiState.previousLocation.org"]',
+      '["userOptions.uiState.previousLocation.instance"]'
     ]
   }).require(),
   mw.body(

--- a/test/users-id.js
+++ b/test/users-id.js
@@ -76,7 +76,8 @@ describe('User - /users/:id', function () {
 
       it('should update the user with the new option', function (done) {
         ctx.user.update({
-          'userOptions.uiState.shownCoachMarks.editButton': true
+          'userOptions.uiState.shownCoachMarks.editButton': true,
+          'userOptions.uiState.previousLocation.instance': 'cheeseburgers'
         }, function (err, body, code) {
           if (err) {
             return done(err);
@@ -87,6 +88,9 @@ describe('User - /users/:id', function () {
             uiState: {
               shownCoachMarks: {
                 editButton: true
+              },
+              previousLocation: {
+                instance: 'cheeseburgers'
               }
             }
           });
@@ -102,7 +106,8 @@ describe('User - /users/:id', function () {
 
       it('should be able to update consecutively without losing data ', function (done) {
         ctx.user.update({
-          'userOptions.uiState.shownCoachMarks.editButton': true
+          'userOptions.uiState.shownCoachMarks.editButton': true,
+          'userOptions.uiState.previousLocation.instance': 'cheeseburgers'
         }, function (err, body, code) {
           if (err) {
             return done(err);
@@ -113,6 +118,9 @@ describe('User - /users/:id', function () {
             uiState: {
               shownCoachMarks: {
                 editButton: true
+              },
+              previousLocation: {
+                instance: 'cheeseburgers'
               }
             }
           });
@@ -128,6 +136,9 @@ describe('User - /users/:id', function () {
                 shownCoachMarks: {
                   editButton: true,
                   repoList: true
+                },
+                previousLocation: {
+                  instance: 'cheeseburgers'
                 }
               }
             });


### PR DESCRIPTION
This enables the UI to store the previous org and instance location that was viewed by the user
