### PR TITLE
fix slow unit test

### DIFF
--- a/unit/route53.js
+++ b/unit/route53.js
@@ -81,13 +81,6 @@ describe('Route53 Unit Tests', function () {
   describe('UPSERT', function () {
     var ctx = {};
     afterEach(function (done) {
-      var params = createParams('DELETE', ctx.url, ctx.ip);
-      var route53 = new AWS.Route53();
-      route53.changeResourceRecordSets(params, function () {
-        done();
-      });
-    });
-    afterEach(function (done) {
       ctx = {};
       done();
     });


### PR DESCRIPTION
turns out the afterEach was being called after the after, which means it was trying to reach out to AWS...

@anandkumarpatel, these seem to be missing some checks - it's much making sure a function gets called... I'm not sure these are _really_ testing anything...
