### PR TITLE
Allow users to fetch HelloRunnable Contexts (for the descriptions)

### DIFF
--- a/lib/routes/contexts/index.js
+++ b/lib/routes/contexts/index.js
@@ -11,6 +11,7 @@ var flow = require('middleware-flow');
 var mw = require('dat-middleware');
 
 var contexts = require('middlewares/mongo').contexts;
+var ownerIsHelloRunnable = require('middlewares/owner-is-hello-runnable');
 var me = require('middlewares/me');
 var validations = require('middlewares/validations');
 var checkFound = require('middlewares/check-found');
@@ -40,6 +41,7 @@ app.get('/contexts/:id',
   findContext,
   flow.or(
     me.isOwnerOf('context'),
+    ownerIsHelloRunnable('context'),
     contexts.model.isPublic(),
     me.isModerator),
   mw.res.json('context')


### PR DESCRIPTION
Since we need to have descriptions for the non-repo servers, we can just use the context's description.  Since we don't own them, we should allow any user to fetch contexts from Hello Runnable

Also, we need to populate the descriptions
