### PR TITLE
Updating the HelloRunnable template context's with descriptions

### DIFF
--- a/scripts/update-source-descriptions.js
+++ b/scripts/update-source-descriptions.js
@@ -120,12 +120,13 @@ function createOtherSources(cb) {
 function updateDescriptions(data, done) {
   if (data.description) {
     console.log('updating description for ', data.name);
+    var query = {
+        'lowerName': data.name.toLowerCase(),
+        'owner.github': process.env.HELLO_RUNNABLE_GITHUB_ID
+      };
     if (!process.env.ACTUALLY_RUN) {
       console.log('Nope, just a dry run');
-      Context.findOne({
-        'name': data.name,
-        'owner.github': process.env.HELLO_RUNNABLE_GITHUB_ID
-      }, function (err, context) {
+      Context.findOne(query, function (err, context) {
         if (err) {
           console.error('Finding context err for ' + data.name, err);
           return done(err);
@@ -135,10 +136,7 @@ function updateDescriptions(data, done) {
         }
       });
     } else {
-      Context.findOneAndUpdate({
-        'name': data.name,
-        'owner.github': process.env.HELLO_RUNNABLE_GITHUB_ID
-      }, {
+      Context.findOneAndUpdate(query, {
         $set: {
           description: data.description
         }


### PR DESCRIPTION
Since we need to have descriptions for the non-repo servers, we can just use the context's description.  Since we don't own them, we should allow any user to fetch contexts from Hello Runnable
