### PR TITLE
pass only owner.github on fork

### DIFF
--- a/lib/models/apis/runnable.js
+++ b/lib/models/apis/runnable.js
@@ -162,7 +162,9 @@ Runnable.prototype.forkMasterInstance = function (masterInst, buildId, branch, c
     build: buildId,
     name: sanitizedBranch + '-' + masterInst.name,
     env:  masterInst.env,
-    owner: masterInst.owner,
+    owner: {
+      github: masterInst.owner.github
+    },
     masterPod: false,
     autoForked: true
   };


### PR DESCRIPTION
The query was failing to find because we we quering by full `owner` object(github, username and gravatar_url)
