### PR TITLE
fix api-client version

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "regexp-quote": "0.0.0",
     "request": "2.42.0",
     "rollbar": "0.5.4",
-    "runnable": "git+ssh://git@github.com:CodeNow/runnable-api-client#v1.1.0",
+    "runnable": "git+ssh://git@github.com:CodeNow/runnable-api-client#v3.0.0",
     "s3-stream-upload": "0.0.6",
     "sauron-client": "git+ssh://git@github.com:codenow/sauron-client.git#v1.0.2",
     "simple-api-client": "^0.5.9",


### PR DESCRIPTION
it got set back to v1.1.0 in @tjmehta's merge commit (https://github.com/CodeNow/api/commit/b37e74d47d1a2b140359419bf383d8e2fcdc0cd1#diff-b9cfc7f2cdf78a7f4b91a753d10865a2). here's the fix
