### PR TITLE
No login cookie share

### DIFF
--- a/lib/routes/auth/github.js
+++ b/lib/routes/auth/github.js
@@ -36,14 +36,20 @@ app.get('/auth/github',
         next();
       }),
   // sets token to current users cookie and redirects back to requester
-  mw.query('requiresToken').require().then(
-    mw.req().set('session.requiresToken', 'query.requiresToken'),
-    token.createWithSessionCookie('session', 'headers.cookie', 'cb'),
-    function (req, res) {
-      debug('redirecting', req.session.authCallbackRedirect);
-      res.redirect(req.session.authCallbackRedirect);
-      delete req.session.authCallbackRedirect;
-    }),
+  mw.query('requiresToken').require()
+    .then(
+      mw.req().set('session.requiresToken', 'query.requiresToken'),
+      // return token now if forceLogin does not exist
+      mw.query('forceLogin').require()
+        .else(
+          token.createWithSessionCookie('session', 'headers.cookie', 'cb'),
+          function (req, res) {
+            debug('redirecting', req.session.authCallbackRedirect);
+            res.redirect(req.session.authCallbackRedirect);
+            delete req.session.authCallbackRedirect;
+          }
+        )
+    ),
   passport.authenticate('github'));
 
 // GET /auth/github/callback
@@ -59,6 +65,7 @@ app.get('/auth/github/callback',
   // if enforcing the whitelist, make sure the requested username is the same as sesionUser,
   // or that it is the name of an org to which the user belongs
   flow.syncIf(enforceAuthWhitelist).then(validateAgainstWhitelist()),
+  token.createWithSessionCookie('session', 'headers.cookie', 'cb'),
   function (req, res) {
     debug('authCallbackRedirect', req.session.authCallbackRedirect);
     res.redirect(req.session.authCallbackRedirect);

--- a/test/auth-github/callback-token.js
+++ b/test/auth-github/callback-token.js
@@ -54,10 +54,57 @@ describe('/auth/github routes', function () {
         done();
       });
     });
-    describe('when requireToken was set in session', function () {
+    it('should pass one time use token with no forceLogin', function (done) {
+      var j = request.jar();
+      var testRedir = 'http://thisredir:9283/datPath?thisqs=great';
+      require('../fixtures/mocks/github/user')(ctx.user, null, testToken);
+      request.get({
+        jar: j,
+        url: baseUrl,
+        followRedirect: false,
+        qs: {
+          requiresToken: 'true',
+          redirect: testRedir
+        }
+      }, function (err, res) {
+        if (err) { return done(err); }
+        expect(res.statusCode).to.equal(302);
+        var testUrl = url.parse(res.headers.location);
+        var qs = querystring.parse(testUrl.query);
+        expect(testUrl.protocol).to.equal('http:');
+        expect(testUrl.host).to.equal('thisredir:9283');
+        expect(testUrl.pathname).to.equal('/datPath');
+        expect(qs.runnableappAccessToken).to.exist();
+        expect(qs.thisqs).to.equal('great');
+        done();
+      });
+    });
+    it('should not pass one time use token with forceLogin', function (done) {
+      var j = request.jar();
+      var testRedir = 'http://thisredir:9283/datPath?thisqs=great';
+      require('../fixtures/mocks/github/user')(ctx.user, null, testToken);
+      request.get({
+        jar: j,
+        url: baseUrl,
+        followRedirect: false,
+        qs: {
+          requiresToken: 'true',
+          redirect: testRedir,
+          forceLogin: 'true'
+        }
+      }, function (err, res) {
+        if (err) { return done(err); }
+        expect(res.statusCode).to.equal(302);
+        var testUrl = url.parse(res.headers.location);
+        var qs = querystring.parse(testUrl.query);
+        expect(qs.runnableappAccessToken).to.not.exist();
+        done();
+      });
+    });
+    describe('when forceLogin was set in session', function () {
       var testRedir = 'http://thisredir:9283/datPath?thisqs=great';
       var j = request.jar();
-      it('should pass one time use token', function (done) {
+      beforeEach(function (done) {
         require('../fixtures/mocks/github/user')(ctx.user, null, testToken);
         request.get({
           jar: j,
@@ -65,8 +112,17 @@ describe('/auth/github routes', function () {
           followRedirect: false,
           qs: {
             requiresToken: 'true',
-            redirect: testRedir
+            redirect: testRedir,
+            forceLogin: 'true'
           }
+        }, done);
+      });
+      it('should pass one time use token', function (done) {
+        request.get({
+          jar: j,
+          url: target,
+          followRedirect: false,
+          qs: { code: testToken }
         }, function (err, res) {
           if (err) { return done(err); }
           expect(res.statusCode).to.equal(302);


### PR DESCRIPTION
product need to be able to view users app domain websites. they can not login to github with other orgs creds. just pass the cookie without going through the auth dance if forceLogin does not exist.
e55pqe-runnable-angular-staging-codenow.runnableapp.com

HEY REVIEWER, YEAH YOU ^ check this if you did them
(Me? Really? Okay!)
- [x] code review person 1 pass
- [x] code review person 2 pass

for test below create hello world on staging, use navi hack to enable url

```
redis-cli lset frontend:[port].[hash]-[repo]-staging-[org].runnable2.net 1 http://10.0.1.41:33402
redis-cli  lset frontend:[port].[repo]-staging-[org].runnable2.net 1 http://10.0.1.41:33402
```
- [x] ensure you can visit url after logging into runnable.io without getting redirected to github
