### PR TITLE
SAN-1181 fix move fs

### DIFF
--- a/lib/middlewares/apis/container-fs.js
+++ b/lib/middlewares/apis/container-fs.js
@@ -120,7 +120,6 @@ module.exports = {
     var path = req.params.path;
     containerFs.del(container, path, function (err) {
       if(err) { return next(err); }
-
       res.send(204);
     });
   }

--- a/unit/middlewares/apis/container-fs.js
+++ b/unit/middlewares/apis/container-fs.js
@@ -4,6 +4,7 @@ var Lab = require('lab');
 var lab = exports.lab = Lab.script();
 var describe = lab.describe;
 var it = lab.it;
+var noop = require('101/noop');
 var Code = require('code');
 var expect = Code.expect;
 var sinon = require('sinon');
@@ -86,7 +87,6 @@ describe('container-fs', function () {
   });
 
   describe('#handlePatch', function () {
-
     it('should take all the data from req.params', function (done) {
       var req = {
         params: {
@@ -97,6 +97,33 @@ describe('container-fs', function () {
         }
       };
       var stub = sinon.stub(containerFsAPI, 'patch');
+      containerFs.handlePatch(req, {}, noop);
+      expect(stub.calledOnce).to.be.true();
+      expect(stub.getCall(0).args[0]).to.equal(req.params.container);
+      expect(stub.getCall(0).args[1]).to.equal(req.params.path);
+      expect(stub.getCall(0).args[2].content).to.equal(req.params.content);
+      expect(stub.getCall(0).args[2].newPath).to.equal(req.params.newPath);
+      stub.restore();
+      done();
+    });
+    it('should take optionally take newPath from req.body', function (done) {
+      var req = {
+        params: {
+          container: 'container-id',
+          path: '/root',
+          content: 'some data'
+        },
+        body: {
+          newPath: '/root/id/'
+        }
+      };
+      var stub = sinon.stub(containerFsAPI, 'patch');
+      containerFs.handlePatch(req, {}, noop);
+      expect(stub.calledOnce).to.be.true();
+      expect(stub.getCall(0).args[0]).to.equal(req.params.container);
+      expect(stub.getCall(0).args[1]).to.equal(req.params.path);
+      expect(stub.getCall(0).args[2].content).to.equal(req.params.content);
+      expect(stub.getCall(0).args[2].newPath).to.equal(req.body.newPath);
       stub.restore();
       done();
     });


### PR DESCRIPTION
Ready for review.
Totally 3 PRs:
- api-client https://github.com/CodeNow/runnable-api-client/pull/113
- runnable-angular https://github.com/CodeNow/runnable-angular/pull/761/
- api https://github.com/CodeNow/api/pull/769

This can be tested on staging. https://runnable.io/CodeNow/SAN-1181-fix-moving-dirs-runnable-angular/.
Try do move files and directories using drag-and-drop.

I hit multiple issues while fixing this bug. So please do review all 3 PRs and ask questions.
