### PR TITLE
San 1882 do not overwrite report attribute

### DIFF
--- a/lib/models/events/docker.js
+++ b/lib/models/events/docker.js
@@ -5,7 +5,7 @@
 
 var Boom = require('dat-middleware').Boom;
 var debug = require('debug')('runnable-api:events:docker');
-var extend = require('extend');
+var assign = require('101/assign');
 var noop = require('101/noop');
 
 var ContextVersion = require('models/mongo/context-version');
@@ -239,7 +239,7 @@ function handleInstanceContainerDie (data, cb) {
 
 function logErr (err, data) {
   if (err.isBoom) {
-    extend(err.data, {
+    err.data = assign(err.data || {}, {
       event: 'die',
       extraData: data
     });


### PR DESCRIPTION
do not override report on error object
ignore connection close mongo error during test
NOTE: errors are now at the bottom of the stack instead of the top.
