### PR TITLE
Fix an issue with `Instance.getMainBranchName`

### DIFF
--- a/lib/models/mongo/instance.js
+++ b/lib/models/mongo/instance.js
@@ -166,11 +166,11 @@ InstanceSchema.statics.getMainBranchName = function (instance) {
   if (!appCodeVersions || appCodeVersions.length <= 0) {
     return null;
   }
-  var contextVersion = ContextVersion.getMainAppCodeVersion(appCodeVersions);
-  if (!contextVersion) {
+  var mainAppCodeVersion = ContextVersion.getMainAppCodeVersion(appCodeVersions);
+  if (!mainAppCodeVersion) {
     return null;
   }
-  return contextVersion.branch;
+  return mainAppCodeVersion.branch;
 };
 /**
  * get branch name of the contextVersion's main appCodeVersion

--- a/unit/models/mongo/instances.js
+++ b/unit/models/mongo/instances.js
@@ -59,13 +59,29 @@ function createNewVersion (opts) {
       dockerImage: "testing",
       dockerTag: "adsgasdfgasdf"
     },
-    appCodeVersions: [{
-      repo: opts.repo || 'bkendall/flaming-octo-nemisis._',
-      lowerRepo: opts.repo || 'bkendall/flaming-octo-nemisis._',
-      branch: opts.branch || 'master',
-      defaultBranch: opts.defaultBranch || 'master',
-      commit: 'deadbeef'
-    }]
+    appCodeVersions: [
+      {
+        additionalRepo: false,
+        repo: opts.repo || 'bkendall/flaming-octo-nemisis._',
+        lowerRepo: opts.repo || 'bkendall/flaming-octo-nemisis._',
+        branch: opts.branch || 'master',
+        defaultBranch: opts.defaultBranch || 'master',
+        commit: 'deadbeef'
+      },
+      {
+        additionalRepo: true,
+        commit: '4dd22d12b4b3b846c2e2bbe454b89cb5be68f71d',
+        branch: 'master',
+        lowerBranch: 'master',
+        repo: 'Nathan219/yash-node',
+        lowerRepo: 'nathan219/yash-node',
+        _id: '5575f6c43074151a000e8e27',
+        privateKey: 'Nathan219/yash-node.key',
+        publicKey: 'Nathan219/yash-node.key.pub',
+        defaultBranch: 'master',
+        transformRules: { rename: [], replace: [], exclude: [] }
+      }
+    ]
   });
 }
 
@@ -126,6 +142,24 @@ describe('Instance', function () {
         expect(err.code).to.equal(11000);
         done();
       });
+    });
+  });
+
+  describe('getMainBranchName', function() {
+    it('should return null when there is no main AppCodeVersion', function(done) {
+      var instance = createNewInstance('no-main-app-code-version');
+      instance.contextVersion.appCodeVersions[0].additionalRepo = true;
+      expect(Instance.getMainBranchName(instance)).to.be.null();
+      done();
+    });
+
+    it('should return the main AppCodeVersion', function(done) {
+      var expectedBranchName = 'somebranchomg';
+      var instance = createNewInstance('no-main-app-code-version', {
+        branch: expectedBranchName
+      });
+      expect(Instance.getMainBranchName(instance)).to.equal(expectedBranchName);
+      done();
     });
   });
 


### PR DESCRIPTION
The `Instance.getMainBranceName` method assumes that the given instance will have a main app-code-version. This may not always be the case because it is called from `setDependenciesFromEnvironment` which may provide an non-repository instance (which by definition do not have a main app-code-version).
