### PR TITLE
keypather@1.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "ip": "^0.3.2",
     "json-hash": "0.0.4",
     "json-stable-stringify": "^1.0.0",
-    "keypather": "^1.8.1",
+    "keypather": "^1.10.1",
     "middleware-flow": "^0.7.0",
     "middlewarize": "0.0.1",
     "mixpanel": "^0.1.0",


### PR DESCRIPTION
We use `keypather.expand` which was introduced in keypather@1.10.x. If someone had stale node_modules and had already installed a keypather > 1.8.x but < 1.10.x their tests would fail.
Updating the package.json ensure the required version of keypather is installed
