### PR TITLE
Check for owner.github

### DIFF
--- a/scripts/add-owner-to-context-versions.js
+++ b/scripts/add-owner-to-context-versions.js
@@ -14,7 +14,7 @@ mongoose.connect(process.env.MONGO);
 
 async.waterfall([
   function getAllCv (cb) {
-    ContextVersion.find({ owner: { $exists: false }}, cb);
+    ContextVersion.find({ 'owner.github': { $exists: false }}, cb);
   },
   function updateCv (cvs, cb) {
     if (typeof cvs !== 'object') {


### PR DESCRIPTION
Fix migration script to update `contextVersion.owner` using `context.owner` when  for all context versions that has no `contextVersion.owner.github`.

Current state of prod:

```
db.contextversions.find({"owner.github": {$exists: false}}).count()
15902
alpha-0:PRIMARY> db.contextversions.find({"owner.github": {$exists: true}}).count()
4246
```

Basically some context versions have empty `owner` as `{}`.
