### PR TITLE
fixed typo in docker events

### DIFF
--- a/lib/models/events/docker.js
+++ b/lib/models/events/docker.js
@@ -344,7 +344,7 @@ function handleImageBuilderDie (data, cb) {
       }, 'docker.getBuildInfo callback');
       if (err) { return updateBuildError(containerId, err, cb); }
       if (buildInfo.failed) {
-        updateBuildError(containerId, buildInfo, cb);
+        ContextVersion.updateBuildCompletedByContainer(containerId, buildInfo, cb);
       }
       else {
         log.trace({


### PR DESCRIPTION
https://runnable.atlassian.net/browse/SAN-2274

"Build logs unavailable" can happen due to image-builder container creation failures..
BUT in this case it seems to be marked incorrectly with a runnable boom error.
ContextVersion's that have non-zero exit codes should not be marked with `build.error` property.

ContextVersion's `build.error` property should be for marking builds that docker responded to with an error. If a build completes with any exit code it should be marked as completed in our database (not errored).
