### PR TITLE
MASTER FIX: bump hermes

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "request": "2.42.0",
     "rollbar": "0.5.4",
     "runnable": "git+ssh://git@github.com:CodeNow/runnable-api-client#v4.2.2",
-    "runnable-hermes": "^2.0.0",
+    "runnable-hermes": "^2.0.1",
     "runnable-hostname": "git+ssh://git@github.com:CodeNow/runnable-hostname#v1.0.4",
     "s3-stream-upload": "0.0.6",
     "sauron-client": "git+ssh://git@github.com:codenow/sauron-client.git#v1.0.2",


### PR DESCRIPTION
hermes was published with a bug in v2.0.0 that was causing api's tests to fail. I published hermes v2.0.1 w/ the correct code and this fixes the tests.
