### PR TITLE
Add datadog monitoring to the socket-client

### DIFF
--- a/lib/socket/socket-client.js
+++ b/lib/socket/socket-client.js
@@ -24,6 +24,7 @@ function SocketClient () {
   var token = process.env.PRIMUS_AUTH_TOKEN;
   var url = process.env.FULL_API_DOMAIN + '?token=' + token;
   this.primusClient = new PrimusSocket(url);
+  dogstatsd.increment('api.socket.client.open-sockets');
   this.primusClient.on('error', function (err) {
     dogstatsd.increment('api.socket.client.err');
     error.log(err);
@@ -119,6 +120,7 @@ SocketClient.prototype.destroy = function () {
   }, 'destroy');
   this.primusClient.end();
   dogstatsd.increment('api.socket.client.destroy');
+  dogstatsd.decrement('api.socket.client.open-sockets');
 };
 
 /**


### PR DESCRIPTION
Add datadog monitoring for the socket client.
Hopefully this metrics would allow us to notice https://github.com/CodeNow/api/pull/932 earlier.
