### PR TITLE
Replace multi.createInstance in tests

### DIFF
--- a/test/instances-id-actions-copy/post/400.js
+++ b/test/instances-id-actions-copy/post/400.js
@@ -27,7 +27,7 @@ describe('400  POST /instances/:id/actions/copy', function () {
   after(require('../../fixtures/mocks/api-client').clean);
 
   beforeEach(function (done) {
-    multi.createInstance(function (err, instance, build, user) {
+    multi.createAndTailInstance(primus, function (err, instance, build, user) {
       if (err) { return done(err); }
       ctx.instance = instance;
       ctx.build = build;

--- a/test/instances-id-dependencies-id/put/200.js
+++ b/test/instances-id-dependencies-id/put/200.js
@@ -31,7 +31,7 @@ describe('Dependencies - /instances/:id/dependencies', function () {
 
   describe('User Instances', function () {
     beforeEach(function (done) {
-      multi.createInstance(function (err, instance, build, user) {
+      multi.createAndTailInstance(primus, function (err, instance, build, user) {
         //[contextVersion, context, build, user], [srcContextVersion, srcContext, moderator]
         if (err) { return done(err); }
         ctx.instance = instance;

--- a/test/instances-id-dependencies-id/put/400.js
+++ b/test/instances-id-dependencies-id/put/400.js
@@ -31,7 +31,7 @@ describe('Dependencies - /instances/:id/dependencies', function () {
 
   describe('User Instances', function () {
     beforeEach(function (done) {
-      multi.createInstance(function (err, instance, build, user) {
+      multi.createAndTailInstance(primus, function (err, instance, build, user) {
         //[contextVersion, context, build, user], [srcContextVersion, srcContext, moderator]
         if (err) { return done(err); }
         ctx.instance = instance;

--- a/test/instances-id-dependencies-id/put/404.js
+++ b/test/instances-id-dependencies-id/put/404.js
@@ -31,7 +31,7 @@ describe('Dependencies - /instances/:id/dependencies', function () {
 
   describe('User Instances', function () {
     beforeEach(function (done) {
-      multi.createInstance(function (err, instance, build, user) {
+      multi.createAndTailInstance(primus, function (err, instance, build, user) {
         //[contextVersion, context, build, user], [srcContextVersion, srcContext, moderator]
         if (err) { return done(err); }
         ctx.instance = instance;

--- a/test/instances-id-dependencies/get/200.js
+++ b/test/instances-id-dependencies/get/200.js
@@ -31,7 +31,7 @@ describe('Dependencies - /instances/:id/dependencies', function () {
 
   describe('User Instances', function () {
     beforeEach(function (done) {
-      multi.createInstance(function (err, instance, build, user) {
+      multi.createAndTailInstance(primus, function (err, instance, build, user) {
         //[contextVersion, context, build, user], [srcContextVersion, srcContext, moderator]
         if (err) { return done(err); }
         ctx.instance = instance;

--- a/test/instances-id/patch/400.js
+++ b/test/instances-id/patch/400.js
@@ -29,7 +29,7 @@ describe('PATCH 400 - /instances/:id', function () {
 
   describe('invalid types', function () {
     beforeEach(function (done) {
-      multi.createInstance(function (err, instance) {
+      multi.createAndTailInstance(primus, function (err, instance) {
         if (err) { return done(err); }
         ctx.instance = instance;
         done();

--- a/test/workers/on-instance-container-create/post/201.js
+++ b/test/workers/on-instance-container-create/post/201.js
@@ -71,6 +71,8 @@ describe('201 POST /workers/on-instance-container-create', function () {
         emitter.removeAllListeners('on-instance-container-create');
       }
     });
+    // Note: this usage of multi.createInstance is right,
+    // elsewhere use multi.createAndTailInstance
     multi.createInstance(function (err, instance, build, user) {
       if (err) { return done(err); }
       ctx.instance = instance;


### PR DESCRIPTION
`multi.createAndTailInstance` should be used in most cases to prevent background work after tests have completed
