### PR TITLE
Test disabling newrelic tracing to see memory impact

### DIFF
--- a/configs/.env.production-beta
+++ b/configs/.env.production-beta
@@ -21,3 +21,4 @@ KRAIN_PORT=3100
 MAVIS_HOST=http://mavis.runnable-beta.com:80
 REGISTRY_DOMAIN=registry.runnable.com
 S3_CONTEXT_RESOURCE_BUCKET=runnable-beta.context.resources.production
+NEW_RELIC_TRACER_ENABLED=false


### PR DESCRIPTION
I am seeing a lot of newrelic `Tracer` instances in our heap dumps. I want to disable newrelic tracing to see if it reduces the memory leak.
