### PR TITLE
Debug Container Labels

### DIFF
--- a/lib/models/mongo/debug-container.js
+++ b/lib/models/mongo/debug-container.js
@@ -15,7 +15,10 @@ DebugContainerSchema.methods.deploy = function (callback) {
 
   var dockerOpts = {
     Cmd: [ 'sleep', '28800' ],
-    Image: this.layerId
+    Image: this.layerId,
+    Labels: {
+      type: 'debug-container'
+    }
   };
 
   async.waterfall([

--- a/unit/models/mongo/debug-containers.js
+++ b/unit/models/mongo/debug-containers.js
@@ -79,6 +79,14 @@ describe('Debug Containers', function () {
       ctx.dc.deploy(function (err, dc) {
         if (err) { return done(err); }
         expect(Docker.prototype.createContainer.calledOnce).to.be.true();
+        var createArgs = Docker.prototype.createContainer.getCall(0).args[0];
+        expect(createArgs).to.deep.equal({
+          Cmd: [ 'sleep', '28800' ],
+          Image: dc.layerId,
+          Labels: {
+            type: 'debug-container'
+          }
+        });
         expect(containerStart.calledOnce).to.be.true();
         expect(containerInspect.calledOnce).to.be.true();
         Docker.prototype.createContainer.restore();


### PR DESCRIPTION
Let's put some labels on the Docker container that's created for debug containers. It will help when looking for them to clean up w/ khronos.
