### PR TITLE
Prevent dedupe away from Advanced

### DIFF
--- a/lib/models/mongo/context-version.js
+++ b/lib/models/mongo/context-version.js
@@ -806,6 +806,9 @@ ContextVersionSchema.methods.dedupeBuild = function (callback) {
       'build.hash': self.build.hash,
       'build._id': { $ne: self.build._id } // ignore self
     };
+    if (exists(self.advanced)) {
+      query.advanced = self.advanced;
+    }
     query = addAppCodeVersionQuery(self, query);
     var opts = {
       sort : 'build.started',
@@ -836,6 +839,9 @@ ContextVersionSchema.methods.dedupeBuild = function (callback) {
       'build.hash': self.build.hash,
       'build._id': { $ne: self.build._id } // ignore self
     };
+    if (exists(self.advanced)) {
+      query.advanced = self.advanced;
+    }
     query = addAppCodeVersionQuery(self, query);
     var opts = {
       sort : '-build.started',


### PR DESCRIPTION
Seeing a problem where dedupes were reverting to non-advanced builds, I found in the dedupe logic where we don't actually preserve the `advanced` flag in the search. This adds that check.

[Runnable Staging](http://ekwz4e-api-staging-codenow.runnableapp.com)
