### PR TITLE
Add relative path to title of each root describe

### DIFF
--- a/unit/builds.js
+++ b/unit/builds.js
@@ -14,7 +14,10 @@ var validation = require('./fixtures/validation')(lab);
 
 var Build = require('models/mongo/build');
 
-describe('Build', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('Build: '+moduleName, function () {
   before(require('./fixtures/mongo').connect);
   afterEach(require('../test/functional/fixtures/clean-mongo').removeEverything);
 

--- a/unit/context-versions.js
+++ b/unit/context-versions.js
@@ -15,7 +15,10 @@ var ContextVersion = require('models/mongo/context-version');
 var validation = require('./fixtures/validation')(lab);
 var Version = require('models/mongo/context-version');
 
-describe('Versions', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('Versions: '+moduleName, function () {
   before(require('./fixtures/mongo').connect);
   afterEach(require('../test/functional/fixtures/clean-mongo').removeEverything);
 

--- a/unit/contexts.js
+++ b/unit/contexts.js
@@ -13,7 +13,10 @@ var validation = require('./fixtures/validation')(lab);
 var schemaValidators = require('../lib/models/mongo/schemas/schema-validators');
 var Context = require('models/mongo/context');
 
-describe('Context Unit Testing', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('Context Unit Testing: '+moduleName, function () {
   before(require('./fixtures/mongo').connect);
   afterEach(require('../test/functional/fixtures/clean-mongo').removeEverything);
 

--- a/unit/error.js
+++ b/unit/error.js
@@ -20,7 +20,10 @@ var ctx = {};
 // this is going to be a little weird, since we have to set NODE_ENV to not be
 // `test` to get this to work. Let's see what happens...
 
-describe('Error', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('Error: '+moduleName, function () {
 
   describe('should send to rollbar', function () {
     beforeEach(function (done) {

--- a/unit/fixtures/validation.js
+++ b/unit/fixtures/validation.js
@@ -48,7 +48,11 @@ module.exports = function (lab) { return new Validator(lab); };
 
 Validator.prototype.githubUserRefValidationChecking = function(createModelFunction, property, isList) {
   var self = this;
-  self.lab.describe('Github User Ref Validation', function () {
+
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+  self.lab.describe('Github User Ref Validation: '+moduleName, function () {
     var word = self.makeStringOfLength(50);
     self.lab.it('should fail validation for an invalid Github User Id (' + word + ')', function (done) {
       var myObject = createModelFunction();

--- a/unit/github-actions.js
+++ b/unit/github-actions.js
@@ -9,7 +9,10 @@ var expect = Code.expect;
 
 var githubActions = require('routes/actions/github');
 
-describe('GitHub Actions', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('GitHub Actions: '+moduleName, function () {
 
   describe('parseGitHubPushData', function () {
 

--- a/unit/hasher.js
+++ b/unit/hasher.js
@@ -23,7 +23,10 @@ var notEquals = function (compare) {
 var equivalentDockerfiles = require('../test/functional/fixtures/equivalent-dockerfiles');
 var differentDockerfiles  = require('../test/functional/fixtures/different-dockerfiles');
 
-describe('Hasher',  function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('Hasher: '+moduleName,  function () {
   describe('stream', function () {
     it('should hash a stream', function (done) {
       var fileStream = fs.createReadStream(__filename);

--- a/unit/hosts.js
+++ b/unit/hosts.js
@@ -14,7 +14,10 @@ require('loadenv')();
 
 var Hosts = require('models/redis/hosts');
 
-describe('Hosts', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('Hosts: '+moduleName, function () {
   describe('parseHostname', function () {
     var ctx = {};
     beforeEach(function (done) {

--- a/unit/infracode-versions.js
+++ b/unit/infracode-versions.js
@@ -15,7 +15,10 @@ var InfracodeVersion = require('../lib/models/mongo/infra-code-version');
 var Boom = require('dat-middleware').Boom;
 var sinon = require('sinon');
 
-describe('Infracode Versions', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('Infracode Versions: '+moduleName, function () {
   before(require('./fixtures/mongo').connect);
   afterEach(require('../test/functional/fixtures/clean-mongo').removeEverything);
 

--- a/unit/is-env-on.js
+++ b/unit/is-env-on.js
@@ -12,7 +12,10 @@ var isEnvOn = require('middlewares/is-env-on');
 var createCount = require('callback-count');
 var noop = require('101/noop');
 
-describe('is-env-on', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('is-env-on: '+moduleName, function () {
 
   it('should call send response if env doesnot exist', function (done) {
     var count = createCount(2, done);

--- a/unit/key-generator.js
+++ b/unit/key-generator.js
@@ -13,7 +13,10 @@ var sinon = require('sinon');
 var keyGen = require('key-generator');
 var Keypair = require('models/mongo/keypair');
 
-describe('KeyGenerator', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('KeyGenerator: '+moduleName, function () {
   var ctx;
   beforeEach(function (done) {
     ctx = {};

--- a/unit/middlewares/apis/container-fs.js
+++ b/unit/middlewares/apis/container-fs.js
@@ -11,7 +11,10 @@ var sinon = require('sinon');
 var containerFs = require('middlewares/apis/container-fs');
 var containerFsAPI = require('models/apis/container-fs');
 
-describe('container-fs', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('container-fs: '+moduleName, function () {
   describe('#parseParams', function () {
     it('should parse params correctly for dir', function (done) {
       var container = '0021da9eb7f3fee201cbc4b42d6efcdb8f494ba9466fb783a46f4527575d880f';

--- a/unit/middlewares/apis/jobs.js
+++ b/unit/middlewares/apis/jobs.js
@@ -15,7 +15,10 @@ var jobs = require('../../../lib/middlewares/apis/jobs.js');
 
 var sinon = require('sinon');
 
-describe('lib/middlewares/apis/jobs.js unit test', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('lib/middlewares/apis/jobs.js unit test: '+moduleName, function () {
   var testReq = {
     body: {
       name: 'nemo'

--- a/unit/middlewares/domains.js
+++ b/unit/middlewares/domains.js
@@ -30,7 +30,10 @@ function testPreSessionRunnableDomainData () {
   expect(process.domain.runnableData.userGithubEmail).to.equal(null);
 }
 
-describe('middlewares/domains unit test', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('middlewares/domains unit test: '+moduleName, function () {
   var ctx = {};
 
   afterEach(function (done) {

--- a/unit/middlewares/owner-is-hello-runnable.js
+++ b/unit/middlewares/owner-is-hello-runnable.js
@@ -15,7 +15,10 @@ var expect = Code.expect;
 var ownerIsHelloRunnable = require('middlewares/owner-is-hello-runnable');
 var clone = require('101/clone');
 
-describe('owner-is-hello-runnable unit test', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('owner-is-hello-runnable unit test: '+moduleName, function () {
   describe('with hello runnable session user', function() {
     var req = {
       sessionUser: {

--- a/unit/middlewares/utils.js
+++ b/unit/middlewares/utils.js
@@ -14,7 +14,10 @@ var expect = Code.expect;
 
 var utils = require('middlewares/utils');
 
-describe('utils unit test', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('utils unit test: '+moduleName, function () {
   describe('formatFieldFilters', function () {
     it('should set the ignored fields as an array on the req object', function (done) {
       var req = {

--- a/unit/models/apis/build-files.js
+++ b/unit/models/apis/build-files.js
@@ -14,7 +14,10 @@ var noop = require('101/noop');
 require('loadenv')();
 var BuildFiles = require('models/apis/build-files');
 
-describe('build-files', function() {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('build-files: '+moduleName, function() {
   var model = new BuildFiles('some-context-id');
 
   describe('copyObject', function() {

--- a/unit/models/apis/docker.js
+++ b/unit/models/apis/docker.js
@@ -17,7 +17,10 @@ var Docker = require('models/apis/docker');
 var Dockerode = require('dockerode');
 var Modem = require('docker-modem');
 
-describe('docker', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('docker: '+moduleName, function () {
   var model = new Docker('http://fake.host.com');
 
   describe('getLogs', function () {

--- a/unit/models/apis/mavis.js
+++ b/unit/models/apis/mavis.js
@@ -14,7 +14,10 @@ var expect = Code.expect;
 var Mavis = require('models/apis/mavis');
 var sinon = require('sinon');
 
-describe('mavis.js unit test', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('mavis.js unit test: '+moduleName, function () {
   var ctx = {};
   beforeEach(function(done) {
     ctx.mavis = new Mavis();

--- a/unit/models/apis/pullrequest.js
+++ b/unit/models/apis/pullrequest.js
@@ -13,7 +13,11 @@ var after = lab.after;
 
 var PullRequest = require('models/apis/pullrequest');
 var GitHub = require('models/apis/github');
-describe('PullRequest', function () {
+
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('PullRequest: '+moduleName, function () {
   var ctx = {};
   before(function (done) {
     ctx.originalStatusFlag = process.env.ENABLE_GITHUB_DEPLOYMENT_STATUSES;

--- a/unit/models/apis/runnable.js
+++ b/unit/models/apis/runnable.js
@@ -11,7 +11,11 @@ var Code = require('code');
 var expect = Code.expect;
 
 var Runnable = require('models/apis/runnable');
-describe('Runnable', function () {
+
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('Runnable: '+moduleName, function () {
   describe('#forkMasterInstance', function () {
     it('should create new instance with branch-masterName pattern', function (done) {
       var runnable = new Runnable({});

--- a/unit/models/auth/token-auth.js
+++ b/unit/models/auth/token-auth.js
@@ -15,7 +15,10 @@ var error = require('error');
 var querystring = require('querystring');
 var url = require('url');
 
-describe('token.js unit test', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('token.js unit test: '+moduleName, function () {
   describe('createWithSessionCookie', function() {
     beforeEach(function(done) {
       sinon.stub(RedisToken.prototype, 'setValue');

--- a/unit/models/graph/neo4j.js
+++ b/unit/models/graph/neo4j.js
@@ -21,7 +21,10 @@ var requiredEnvVars = {
 };
 
 var ctx = { savedEnvVars: {} };
-describe('neo4j driver', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('neo4j driver: '+moduleName, function () {
   var graph;
   before(function (done) {
     Object.keys(requiredEnvVars).forEach(function (key) {

--- a/unit/models/mongo/context-version.js
+++ b/unit/models/mongo/context-version.js
@@ -24,7 +24,10 @@ var ContextVersion = require('models/mongo/context-version');
 var InfraCodeVersion = require('models/mongo/infra-code-version');
 
 var ctx = {};
-describe('Context Version', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('Context Version: '+moduleName, function () {
   before(require('../../fixtures/mongo').connect);
   afterEach(require('../../../test/functional/fixtures/clean-mongo').removeEverything);
 

--- a/unit/models/mongo/debug-containers.js
+++ b/unit/models/mongo/debug-containers.js
@@ -19,7 +19,11 @@ var Instance = require('models/mongo/instance');
 var ContextVersion = require('models/mongo/context-version');
 
 var ctx = {};
-describe('Debug Containers', function () {
+
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('Debug Containers: '+moduleName, function () {
   before(require('../../fixtures/mongo').connect);
   beforeEach(require('../../../test/functional/fixtures/clean-mongo').removeEverything);
   afterEach(require('../../../test/functional/fixtures/clean-mongo').removeEverything);

--- a/unit/models/mongo/instances.js
+++ b/unit/models/mongo/instances.js
@@ -129,7 +129,10 @@ function createNewInstance (name, opts) {
   });
 }
 
-describe('Instance', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('Instance: '+moduleName, function () {
   // jshint maxcomplexity:5
   before(require('../../fixtures/mongo').connect);
   afterEach(require('../../../test/functional/fixtures/clean-mongo').removeEverything);

--- a/unit/models/mongo/schemas/instances.js
+++ b/unit/models/mongo/schemas/instances.js
@@ -24,7 +24,10 @@ function getNextHash () {
   return hashids.encrypt(getNextId())[0];
 }
 
-describe('Instance', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('Instance: '+moduleName, function () {
   before(require('../../../fixtures/mongo').connect);
   afterEach(require('../../../../test/functional/fixtures/clean-mongo').removeEverything);
 

--- a/unit/models/rabbitmq.js
+++ b/unit/models/rabbitmq.js
@@ -19,7 +19,10 @@ var afterEach = lab.afterEach;
 var beforeEach = lab.beforeEach;
 var expect = Code.expect;
 
-describe('RabbitMQ Model', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('RabbitMQ Model: '+moduleName, function () {
   var ctx;
   beforeEach(function (done) {
     ctx = {};

--- a/unit/models/services/instance-service.js
+++ b/unit/models/services/instance-service.js
@@ -15,7 +15,10 @@ var it = lab.it;
 var describe = lab.describe;
 var expect = Code.expect;
 
-describe('InstanceService', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('InstanceService: '+moduleName, function () {
 
   describe('#deleteForkedInstancesByRepoAndBranch', function () {
 

--- a/unit/redis-mutex.js
+++ b/unit/redis-mutex.js
@@ -13,8 +13,10 @@ var createCount = require('callback-count');
 var RedisMutex = require('models/redis/mutex');
 var redis = require('models/redis');
 
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
 
-describe('RedisMutex', function () {
+describe('RedisMutex: '+moduleName, function () {
   before(function (done) {
     redis.flushdb(done);
   });

--- a/unit/req-utils.js
+++ b/unit/req-utils.js
@@ -8,7 +8,10 @@ var it = lab.it;
 
 var reqUtils = require('req-utils');
 
-describe('req-utils.js unit test', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('req-utils.js unit test: '+moduleName, function () {
   describe('getProtocol', function() {
     it('should return http', function(done) {
       var testReq = {

--- a/unit/send-and-next.js
+++ b/unit/send-and-next.js
@@ -11,7 +11,10 @@ var resSendAndNext = require('middlewares/send-and-next');
 var createCount = require('callback-count');
 var sinon = require('sinon');
 
-describe('send-and-next', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('send-and-next: '+moduleName, function () {
   it('should call next and send response with status code', function (done) {
     var count = createCount(2, done);
     var req = {};

--- a/unit/settings.js
+++ b/unit/settings.js
@@ -11,7 +11,10 @@ var expect = Code.expect;
 
 var Settings = require('models/mongo/settings');
 
-describe('Settings',  function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('Settings: '+moduleName,  function () {
   before(require('./fixtures/mongo').connect);
   afterEach(require('../test/functional/fixtures/clean-mongo').removeEverything);
 

--- a/unit/slack.js
+++ b/unit/slack.js
@@ -11,7 +11,10 @@ var expect = Code.expect;
 
 var Slack = require('notifications/slack');
 
-describe('Slack', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('Slack: '+moduleName, function () {
   describe('#notifyOnAutoDeploy', function () {
     it('should do nothing if slack messaging is disabled', function (done) {
       var slack = new Slack();

--- a/unit/socket-server.js
+++ b/unit/socket-server.js
@@ -32,7 +32,10 @@ var primusClient = Primus.createSocket({
   parser: 'JSON'
 });
 
-describe('socket-server', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('socket-server: '+moduleName, function () {
 
   describe('init test', function () {
     it('should error if no server passed in', function (done) {

--- a/unit/socket/build-stream.js
+++ b/unit/socket/build-stream.js
@@ -33,7 +33,10 @@ ClientStream.prototype.write = function (data) {
 ClientStream.prototype.end = function () { this.emit('end'); };
 
 var ctx = {};
-describe('build stream', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('build stream: '+moduleName, function () {
   before(function (done) {
     var socket = {};
     var id = 4;

--- a/unit/sockets/messenger.js
+++ b/unit/sockets/messenger.js
@@ -15,7 +15,10 @@ var Messenger = require('socket/messenger');
 // var User = require('models/mongo/user');
 
 
-describe('Messenger', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('Messenger: '+moduleName, function () {
   describe('#canJoin', function () {
     it('should return true if authToken provided', function (done) {
       var socket = {

--- a/unit/timers.js
+++ b/unit/timers.js
@@ -16,7 +16,10 @@ var spyOnMethod = require('function-proxy').spyOnMethod;
 
 var ctx = {};
 
-describe('Timers', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('Timers: '+moduleName, function () {
   describe('instantiation', function () {
     it('should instantiate a timer', function (done) {
       var t;

--- a/unit/token.js
+++ b/unit/token.js
@@ -10,7 +10,10 @@ var beforeEach = lab.beforeEach;
 var redis = require('models/redis');
 var Token = require('models/redis/token');
 
-describe('token.js unit test', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('token.js unit test '+moduleName, function () {
   var token;
   beforeEach(function(done) {
     redis.flushdb(done);

--- a/unit/users.js
+++ b/unit/users.js
@@ -12,7 +12,10 @@ var validation = require('./fixtures/validation')(lab);
 
 var User = require('models/mongo/user');
 
-describe('User', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('User :'+moduleName, function () {
   before(require('./fixtures/mongo').connect);
   afterEach(require('../test/functional/fixtures/clean-mongo').removeEverything);
 

--- a/unit/workers/base-worker.js
+++ b/unit/workers/base-worker.js
@@ -23,7 +23,10 @@ var describe = lab.describe;
 var expect = Code.expect;
 var it = lab.it;
 
-describe('BaseWorker', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('BaseWorker: '+moduleName, function () {
   var ctx;
 
   beforeEach(function (done) {

--- a/unit/workers/create-image-builder-container.js
+++ b/unit/workers/create-image-builder-container.js
@@ -23,8 +23,10 @@ var describe = lab.describe;
 var expect = Code.expect;
 var it = lab.it;
 
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
 
-describe('CreateImageBuilderContainerWorker', function () {
+describe('CreateImageBuilderContainerWorker: '+moduleName, function () {
   var ctx;
 
   beforeEach(function (done) {

--- a/unit/workers/create-instance-container.js
+++ b/unit/workers/create-instance-container.js
@@ -18,7 +18,10 @@ var Instance = require('models/mongo/instance');
 var ContextVersion = require('models/mongo/context-version');
 
 
-describe('Worker: create-instance-container', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('Worker: create-instance-container: '+moduleName, function () {
   describe('#_handleAppError', function () {
     it('should return error if instance.findId returned error', function (done) {
       var worker = new CreateInstanceContainer();

--- a/unit/workers/delete-instance-container.js
+++ b/unit/workers/delete-instance-container.js
@@ -17,8 +17,10 @@ var Hosts = require('models/redis/hosts');
 var Sauron = require('models/apis/sauron');
 var User = require('models/mongo/user');
 
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
 
-describe('Worker: delete-instance-container', function () {
+describe('Worker: delete-instance-container: '+moduleName, function () {
 
   describe('#_findGitHubUsername', function () {
     it('should fail if User.findById failed', function (done) {

--- a/unit/workers/delete-instance.js
+++ b/unit/workers/delete-instance.js
@@ -16,7 +16,10 @@ var Instance = require('models/mongo/instance');
 var messenger = require('socket/messenger');
 var rabbitMQ = require('models/rabbitmq');
 
-describe('Worker: delete-instance', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('Worker: delete-instance: '+moduleName, function () {
 
   describe('#handle', function () {
     it('should fail job if _baseWorkerFindInstance call failed', function (done) {

--- a/unit/workers/on-dock-removed.js
+++ b/unit/workers/on-dock-removed.js
@@ -16,7 +16,10 @@ var sinon = require('sinon');
 var Instance = require('models/mongo/instance');
 var Worker = require('workers/on-dock-removed');
 
-describe('worker: on-dock-removed unit test', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('worker: on-dock-removed unit test: '+moduleName, function () {
   var worker;
   beforeEach(function (done) {
     done();

--- a/unit/workers/on-image-builder-container-create.js
+++ b/unit/workers/on-image-builder-container-create.js
@@ -24,7 +24,10 @@ var describe = lab.describe;
 var expect = Code.expect;
 var it = lab.it;
 
-describe('OnCreateImageBuilderContainer', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('OnCreateImageBuilderContainer: '+moduleName, function () {
   var ctx;
 
   beforeEach(function (done) {

--- a/unit/workers/on-image-builder-container-die.js
+++ b/unit/workers/on-image-builder-container-die.js
@@ -23,7 +23,10 @@ var describe = lab.describe;
 var expect = Code.expect;
 var it = lab.it;
 
-describe('OnImageBuilderContainerDie', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('OnImageBuilderContainerDie: '+moduleName, function () {
   var ctx;
 
   beforeEach(function (done) {

--- a/unit/workers/on-instance-container-create.js
+++ b/unit/workers/on-instance-container-create.js
@@ -22,7 +22,10 @@ var describe = lab.describe;
 var expect = Code.expect;
 var it = lab.it;
 
-describe('OnInstanceContainerCreateWorker', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('OnInstanceContainerCreateWorker: '+moduleName, function () {
   var ctx;
 
   beforeEach(function (done) {

--- a/unit/workers/on-instance-container-die.js
+++ b/unit/workers/on-instance-container-die.js
@@ -17,7 +17,10 @@ var describe = lab.describe;
 var it = lab.it;
 var expect = Code.expect;
 
-describe('OnInstanceContainerDie', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('OnInstanceContainerDie: '+moduleName, function () {
   var ctx;
 
   beforeEach(function (done) {

--- a/unit/workers/on-instance-container-start.js
+++ b/unit/workers/on-instance-container-start.js
@@ -20,7 +20,10 @@ var describe = lab.describe;
 var expect = Code.expect;
 var it = lab.it;
 
-describe('OnInstanceContainerStartWorker', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('OnInstanceContainerStartWorker: '+moduleName, function () {
   var ctx;
 
   beforeEach(function (done) {

--- a/unit/workers/start-instance-container.js
+++ b/unit/workers/start-instance-container.js
@@ -20,7 +20,10 @@ var describe = lab.describe;
 var expect = Code.expect;
 var it = lab.it;
 
-describe('StartInstanceContainerWorker', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('StartInstanceContainerWorker: '+moduleName, function () {
   var ctx;
 
   beforeEach(function (done) {

--- a/unit/workers/stop-instance-container.js
+++ b/unit/workers/stop-instance-container.js
@@ -21,7 +21,10 @@ var describe = lab.describe;
 var expect = Code.expect;
 var it = lab.it;
 
-describe('StopInstanceContainerWorker', function () {
+var path = require('path');
+var moduleName = path.relative(process.cwd(), __filename);
+
+describe('StopInstanceContainerWorker: '+moduleName, function () {
   var ctx;
 
   beforeEach(function (done) {


### PR DESCRIPTION
Adding a relative filepath to the root describe block of each test file to aid in quickly finding a relevant test file when debugging failing tests. These changes were applied via a macro.

Goal is to eliminate need to perform the following to locate the relevant file:
`grep -R "Context Unit Testing" unit/`

This is just a proposal. I would find it very helpful to have functionality like this.

Example unit test output with this change:

```
Context Unit Testing: unit/contexts.js
  ✔ 45) should be able to save a context! (2 ms)
  Contexts Name Validation
    Url-Safe Validation
      ✔ 46) should fail validation for Mabelle.OKeefe@vladimir.info (3 ms)
      ✔ 47) should fail validation for natus fuga eaque eum (2 ms)
      ✔ 48) should fail validation for 4t523456&^()*&^)*&^)*(&^)*&^ (2 ms)
      ✔ 49) should succeed validation for Adonis (6 ms)
      ✔ 50) should succeed validation for Cathryn (5 ms)
      ✔ 51) should succeed validation for 507c7f79bcf86cd7994f6c0e (7 ms)
    name Required Validation
      ✔ 52) name should fail validation because it is required (2 ms)
  Context Github Owner User Id Validation
    Github User Ref Validation: unit/fixtures/validation.js
      ✔ 53) should fail validation for an invalid Github User Id (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) (2 ms)
      ✔ 54) owner.github should succeed validation for a valid Github User Id (5 ms)
  Contexts Description Validation
    Length Validation
      ✔ 55) should succeed length validation for a string of length 500 (6 ms)
      ✔ 56) should fail length validation for a string of length 501 (2 ms)
Error: unit/error.js
  should send to rollbar
    ✔ 57) log to rollbar with data (10 ms)
    ✔ 58) log to rollbar with log levels (2 ms)
GitHub Actions: unit/github-actions.js
  parseGitHubPushData
    ✔ 59) should return error if req.body.repository not found (1 ms)
    ✔ 60) should parse headCommit as {} if req.body.head_commit is null (1 ms)
    ✔ 61) should return error if req.body.ref not found (0 ms)
    ✔ 62) should parse branch and default to [] for commmitLog (1 ms)
Hasher: unit/hasher.js
  stream
    ✔ 63) should hash a stream (5 ms)
    all combinations of chunks
      ✔ 64) should result in the correct hash (274 ms)
    compare stream hash to string hash
      ✔ 65) should result in the same hashes (25 ms)
  string
    ✔ 66) should hash a string (1 ms)
    whitespace comparisons
      whitespace equivalent dockerfiles
        keep whitespace
          ✔ 67) should get different hashes for whitespace-equivalent files (2 ms)
        remove whitespace
          ✔ 68) should get the same hashes for whitespace-equivalent files (2 ms)
      different dockerfiles (not whitespace equivalent)
        keep whitespace
          ✔ 69) should get different hashes for whitespace-equivalent files (2 ms)
        remove whitespace
          ✔ 70) should get different hashes for different files (2 ms)
Hosts: unit/hosts.js
```
