### PR TITLE
Fix EADDRINUSE on Uncaught Exception

### DIFF
--- a/app.js
+++ b/app.js
@@ -162,6 +162,8 @@ Api.prototype._handleStopSignal = function () {
     if (cluster.isWorker) {
       // workers need to be exited manually
       self._waitForActiveHandlesAndExit();
+    } else {
+      process.exit();
     }
   });
 };
@@ -216,7 +218,6 @@ process.on('uncaughtException', function(err) {
   var oldApi = api;
   oldApi.stop(function() {
     log.trace('API stopped');
-    api = new ApiServer();
-    api.start();
+    process.exit(1);
   });
 });


### PR DESCRIPTION
need to start the server after the previous one stopped, not in parallel.

Extra signal handler for testing. Need to remove it after testing on beta or staging (either works)
- [x] test on beta or staging
- [x] remove second commit (SIGHUP handler)
