### PR TITLE
Better error reporting for SocketClient

### DIFF
--- a/lib/socket/socket-client.js
+++ b/lib/socket/socket-client.js
@@ -32,7 +32,7 @@ function SocketClient () {
       tx: true,
       url: url,
       err: boomErr
-    }, 'SocketClient.error');
+    }, 'SocketClient.primusClient.error');
   });
   this.primusClient.on('data', function (data) {
     var eventData = data.data;


### PR DESCRIPTION
1. avoid `Error: unknown` message: https://rollbar.com/Runnable-2/api/items/4574/occurrences/8078363957/
2. use loggly
