### PR TITLE
Update hermes-private dep from v7.5.0 to v8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "fn-object": "~0.2.2",
     "github": "git+ssh://git@github.com/podviaznikov/node-github.git#66dc2d069c59585cc166d87472fb22f7573f9ff5",
     "hashids": "^0.3.3",
-    "hermes-private": "git+ssh://git@github.com:CodeNow/hermes-private#v7.5.0",
+    "hermes-private": "git+ssh://git@github.com:CodeNow/hermes-private#v8.0.0",
     "http-proxy": "^1.5.3",
     "i": "^0.3.2",
     "ip": "^0.3.2",


### PR DESCRIPTION
Hermes update doesn't include any functionality changes, just renamed a few private member properties to have `_` prefix
