### PR TITLE
Add logic enabling src logging in !production

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -81,7 +81,7 @@ module.exports = bunyan.createLogger({
   streams: streams,
   serializers: serializers,
   // DO NOT use src in prod, slow
-  src: !!process.env.LOG_SRC,
+  src: !envIs('production'),
   // default values included in all log objects
   branch: process.env.VERSION_GIT_COMMIT,
   commit: process.env.VERSION_GIT_BRANCH,


### PR DESCRIPTION
Unfortunately, enabling `src` would have adverse performance effects if we enabled it in production, however this feature of bunyan is very useful for testing & local development.

When debugging logic w/ tests:`LOG_LEVEL_STDOUT=trace npm run bdd-whitelist | bunyan -c "this.module === 'lib/models/api.js'" -o json --strict | json -d ' -|- ' -ga module msg src.line src.func`

Produces output similar to:

```
lib/models/api.js -|- api.createClient -|- 67 -|- api.createClient
lib/models/api.js -|- api.createClient session api cookie -|- 82 -|- api.createClient
lib/models/api.js -|- api._handleElasticUrl -|- 275 -|- api._handleElasticUrl
lib/models/api.js -|- api._handleElasticUrl checkReferer -|- 279 -|- checkReferer
lib/models/api.js -|- api._handleElasticUrl checkReferer !refererUrl -|- 281 -|- checkReferer
lib/models/api.js -|- api._handleElasticUrl checkForMapping -|- 395 -|- checkForMapping
lib/models/api.js -|- api._handleElasticUrl findUserMapping -|- 435 -|- findUserMapping
```
