### PR TITLE
Frontend needs LastBuiltSimpleCv to not care if it was successful or not

### DIFF
--- a/lib/routes/instances/index.js
+++ b/lib/routes/instances/index.js
@@ -454,16 +454,14 @@ app.patch('/instances/:id',
       mw.req().set('oldContextVersion', 'instance.contextVersion'),
       mw.req('oldContextVersion.advanced').require().validate(validations.equals(false))
         .then(
-          mw.req('oldContextVersion.build.completed').require()
-            .then(
-              function (req, res, next) {
-                var oldCvId = keypather.get(req, 'oldContextVersion._id');
-                req.body.lastBuiltSimpleContextVersion = {
-                  id: oldCvId,
-                  created: Date.now()
-                };
-                next();
-              })),
+            function (req, res, next) {
+              var oldCvId = keypather.get(req, 'oldContextVersion._id');
+              req.body.lastBuiltSimpleContextVersion = {
+                id: oldCvId,
+                created: Date.now()
+              };
+              next();
+            }),
       // without toJSON - mongoose inf loops.
       mw.body().set('contextVersion', 'contextVersion.toJSON()'),
       // remove all instances where branch equals main branch from the build


### PR DESCRIPTION
We need the 'LastBuiltSimpleCv' to be set any time a basic cv is replaced on an instance, regardless if it was successful or not
