### PR TITLE
Fix for allowing preview header through github proxy

### DIFF
--- a/lib/routes/github/index.js
+++ b/lib/routes/github/index.js
@@ -36,6 +36,7 @@ var corsHeaders = [
   'access-control-max-age',
   'strict-transport-security'
 ]
+var githubAcceptPreviewHeader = 'application/vnd.github.ironman-preview+json'
 var cacheOmitHeaders = [
   'date',
   'x-ratelimit-reset',
@@ -64,6 +65,9 @@ proxy.on('proxyReq', function (proxyReq, req) {
       etag: etag
     }, 'proxyReq')
     proxyReq.setHeader('if-none-match', etag)
+  }
+  if (req.headers['accept'] && req.headers['accept'] === githubAcceptPreviewHeader) {
+    proxyReq.setHeader('accept', req.headers['accept'])
   }
 })
 


### PR DESCRIPTION
For some of the preview features that we're going to be using from the github api, we need to allow the UI to send the custom header through the proxy.  This checks for the modified header, and adds it to the proxied header if found
