### PR TITLE
SAN-3056 userland-hipache redis entry scan script

### DIFF
--- a/scripts/hipache-redis-entry-scan.js
+++ b/scripts/hipache-redis-entry-scan.js
@@ -31,7 +31,6 @@ var redisClient = redis.createClient(
 )
 
 var Instance = require('models/mongo/instance')
-var User = require('models/mongo/user')
 
 var instancesMissingHipache = []
 var instancesWithHipache = []


### PR DESCRIPTION
Script to compare instance documents in mongodb to userland-hipache redis entries to automate finding any missing redis-entries. Part of diagnostics on SAN-3056

https://runnable.atlassian.net/browse/SAN-3056
### Requested Reviews:
- [x] @thejsj 
