### PR TITLE
remove unnecessary domains

### DIFF
--- a/lib/middlewares/validate-auth-redirect.js
+++ b/lib/middlewares/validate-auth-redirect.js
@@ -11,15 +11,14 @@ var url = require('url')
 var log = require('middlewares/logger')(__filename).log
 
 var validRedirectTLDs = [
-  'codenow.com',
-  'runnable-beta.com',
+  // gamma
   'runnable-gamma.com',
-  'runnable.com',
-  'runnable.io',
   'runnable.ninja',
+  // production
+  'runnable.io',
   'runnableapp.com',
-  'runnablecloud.com',
-  'runnablecodesnippets.com'
+  // staging
+  'runnablecloud.com'
 ]
 
 module.exports = function (req, res, next) {


### PR DESCRIPTION
remove domains that are unnecessary:
- `codenow.com` isn't a thing we've ever used
- `runnable-beta.com` doesn't exist any longer
- `runnablecodesnippets.com` we never redirect to

organized them by environment to make it easier to grawk
