### PR TITLE
Add req.body to trace log metadata

### DIFF
--- a/lib/express-app.js
+++ b/lib/express-app.js
@@ -57,7 +57,9 @@ app.use(require('routes/actions/github'))
 app.use(require('middlewares/session'))
 app.use(passport.initialize({ userProperty: 'sessionUser' }))
 app.use(passport.session())
-// attach session properties to domain
+/**
+ * Attach session properties and request body (if present) to domain
+ */
 app.use(require('middlewares/domains').updateDomain)
 app.use(require('routes/auth'))
 app.use(require('routes/auth/github'))

--- a/lib/middlewares/domains.js
+++ b/lib/middlewares/domains.js
@@ -73,7 +73,8 @@ function getRunnableData (req) {
     runnableData = {
       tid: uuid.v4(),
       url: req.method.toUpperCase() + ' ' + req.url,
-      reqStart: new Date()
+      reqStart: new Date(),
+      reqBody: req.body
     }
   }
   defaults(runnableData, {


### PR DESCRIPTION
Will be helpful when inspecting logs. If the request has a body, attach it to the trace log metadata.
- [x] @anandkumarpatel 
- [x] @podviaznikov 
