### PR TITLE
ASAP - Fix to stop _removeExtraKeys from modifying the original value

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -5,7 +5,6 @@
 require('loadenv')()
 
 var bunyan = require('bunyan')
-var clone = require('101/clone')
 var del = require('101/del')
 var envIs = require('101/env-is')
 var keypather = require('keypather')()
@@ -113,7 +112,7 @@ function _removeExtraKeys (data) {
   if (data.toJSON) {
     data = data.toJSON()
   }
-  var newData = {};
+  var newData = {}
   if (typeof data === 'object') {
     Object.keys(data).forEach(function (key) {
       if (data[key].toJSON) {

--- a/unit/logger.js
+++ b/unit/logger.js
@@ -176,7 +176,7 @@ describe('lib/logger.js unit test', function () {
     })
 
     it('should toJSON first-level-subdocuments and remove extra keys', function (done) {
-      function toJSON() {
+      function toJSON () {
         return {
           data: {
             owner: {


### PR DESCRIPTION
This fixes the issue introduced into _removeExtraKeys that caused it to modify the original object
Adding test to make sure this doesn't happen
