### PR TITLE
Update Lab

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "callback-count": "~0.1.0",
     "cayley": "^0.2.0",
     "cluster-man": "^1.1.1",
-    "code": "^1.4.0",
+    "code": "^1.5.0",
     "compression": "^1.0.11",
     "concat-stream": "^1.4.7",
     "connect-datadog": "0.0.5",


### PR DESCRIPTION
Yay for having the latest testing framework that we can use!

They upped the node requirement for lab 7+ and code 2+ to node 4, so we're stuck here until we upgrade or change testing frameworks.
