### PR TITLE
Fix create-image-builder-container error handler

### DIFF
--- a/lib/workers/create-image-builder-container.js
+++ b/lib/workers/create-image-builder-container.js
@@ -249,7 +249,10 @@ CreateImageBuilderContainerWorker.prototype._updateCvOnError = function (origina
         put({
           err: err
         }, self.logData),
-        'CreateImageBuilderContainerWorker updateBuildErrorByBuildId failed')
+        'CreateImageBuilderContainerWorker updateBuildErrorByBuildId failed'
+      )
+      cb(err)
+      return
     }
     cb(originalError)
   })

--- a/unit/workers/create-image-builder-container.js
+++ b/unit/workers/create-image-builder-container.js
@@ -519,18 +519,6 @@ describe('CreateImageBuilderContainerWorker: ' + moduleName, function () {
         done()
       })
 
-      it('should update the build with the error', function (done) {
-        var originalError = new Error('something wicked')
-        ctx.worker._updateCvOnError(originalError, function () {
-          expect(ContextVersion.updateBuildErrorByBuildId.calledOnce)
-            .to.be.true()
-          expect(ContextVersion.updateBuildErrorByBuildId.calledWith(
-            buildId, originalError
-          )).to.be.true()
-          done()
-        })
-      })
-
       it('should callback with the original error', function (done) {
         var originalError = new Error('this way comes')
         ctx.worker._updateCvOnError(originalError, function (err) {


### PR DESCRIPTION
The method that sets the error condition on a context version was incorrectly passing the context version update error and not the original error to the callback.
- [ ] Reviewer 1
- [ ] Reviewer 2
