### PR TITLE
FIX MASTER TESTS

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "through2": "^2.0.0",
     "underscore.string": "^3.0.2",
     "uuid": "~1.4.1",
-    "ws": "^0.4.31",
+    "ws": "~0.4.31",
     "xtend": "3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- removed a bunch of deps that were no longer required. useful.
- fixed ONE package to only accept patch updates (`~`, not `^`) (`slack-client`)

Turns out that `slack-client` updated it's `ws` dependency to `0.8` or something and ours installs `0.4` in the root directory. Guess which one was probably being loaded by `slack-client`?
