### PR TITLE
use forked instance for notifications

### DIFF
--- a/lib/routes/actions/github.js
+++ b/lib/routes/actions/github.js
@@ -515,7 +515,7 @@ function processInstanceAutoForkEvents (req, res, next) {
         // set deployment status to success
         var accessToken = getAccessToken(req)
         var pullRequest = new PullRequest(accessToken)
-        pullRequest.deploymentSucceeded(req.githubPushInfo, instance)
+        pullRequest.deploymentSucceeded(req.githubPushInfo, forkedInstance)
         // save current istance to teh array of deployed instances
         req.deployedInstances.push(instance)
         // report event to the heap. fire and forget


### PR DESCRIPTION
makes for a quick fix of a bug. a better explanation of the bug is on the [jira ticket](https://runnable.atlassian.net/browse/SAN-3404)

Reviewers:
- [x] @podviaznikov 
- [x] @anandkumarpatel!
