### PR TITLE
reorder instance.setContainerStateToStartingAsync

### DIFF
--- a/lib/models/services/instance-service.js
+++ b/lib/models/services/instance-service.js
@@ -401,24 +401,27 @@ InstanceService.startInstance = function (instanceData, sessionUserGithubId) {
     .then(function () {
       var dockRemoved = keypather.get(instance, 'contextVersion.dockRemoved')
       if (dockRemoved) {
-        log.trace(logData, 'startInstance redeploy')
+        log.trace(put({ instance: instance.toJSON() }, logData), 'startInstance dockRemoved: need to redeploy')
         rabbitMQ.redeployInstanceContainer({
           instanceId: instance._id,
           sessionUserGithubId: sessionUserGithubId
         })
         return
       }
-      log.trace(logData, 'startInstance start')
-      rabbitMQ.startInstanceContainer({
-        dockerContainer: instance.container.dockerContainer,
-        dockerHost: instance.container.dockerHost,
-        instanceId: instance._id.toString(),
-        ownerUsername: instance.owner.username,
-        sessionUserGithubId: sessionUserGithubId,
-        tid: keypather.get(process.domain, 'runnableData.tid.toString()')
-      })
-      log.trace(logData, 'startInstance mark as starting')
+
+      log.trace(put({ instance: instance.toJSON() }, logData), 'startInstance marking as starting')
       return instance.setContainerStateToStartingAsync()
+        .then(function () {
+          log.trace(put({ instance: instance.toJSON() }, logData), 'startInstance publish start job')
+          rabbitMQ.startInstanceContainer({
+            dockerContainer: instance.container.dockerContainer,
+            dockerHost: instance.container.dockerHost,
+            instanceId: instance._id.toString(),
+            ownerUsername: instance.owner.username,
+            sessionUserGithubId: sessionUserGithubId,
+            tid: keypather.get(process.domain, 'runnableData.tid.toString()')
+          })
+        })
     })
 }
 

--- a/unit/models/services/instance-service.js
+++ b/unit/models/services/instance-service.js
@@ -896,7 +896,7 @@ describe('InstanceService: ' + moduleName, function () {
         expect(err.message).to.equal(testErr.message)
         sinon.assert.calledOnce(Instance.prototype.isNotStartingOrStoppingAsync)
         sinon.assert.calledOnce(Instance.prototype.setContainerStateToStartingAsync)
-        sinon.assert.calledOnce(rabbitMQ.startInstanceContainer)
+        sinon.assert.notCalled(rabbitMQ.startInstanceContainer)
         sinon.assert.notCalled(rabbitMQ.redeployInstanceContainer)
         done()
       })


### PR DESCRIPTION
there is a race when we update mongo with starting after we get the started container event. fix that race by updating db before we call start container
- [x] @podviaznikov 
- [x] @Myztiq 
# test
- [x] tested starting container
- [x] tested restarting container
