### PR TITLE
SAN-3451 Fix containers that don't get createContainer triggered

### DIFF
--- a/lib/models/mongo/instance.js
+++ b/lib/models/mongo/instance.js
@@ -1250,20 +1250,13 @@ InstanceSchema.statics.findInstancesLinkedToBranch = function (repo, branch, cb)
  * @param {Array}    ContextVersions ids
  * @param {Function} Callback
  */
-InstanceSchema.statics.findByContextVersionId = function (contextVersionIds, cb) {
+InstanceSchema.statics.findByContextVersionIds = function (contextVersionIds, cb) {
   log.info({
     tx: true,
     contextVersionIds: contextVersionIds
-  }, 'InstanceSchema.statics.findByContextVersionId')
-  var query
-  if (Array.isArray(contextVersionIds)) {
-    query = {
-      'contextVersion._id': { $in: contextVersionIds }
-    }
-  } else {
-    query = {
-      'contextVersion._id': contextVersionIds
-    }
+  }, 'InstanceSchema.statics.findByContextVersionIds')
+  var query = {
+    'contextVersion._id': { $in: contextVersionIds }
   }
   this.find(query, cb)
 }

--- a/lib/workers/on-image-builder-container-die.js
+++ b/lib/workers/on-image-builder-container-die.js
@@ -184,7 +184,7 @@ OnImageBuilderContainerDie.prototype._handleBuildComplete = function (buildInfo,
         '_handleBuildComplete: Finding instances by CV ids and updating builds'
       )
       return Promise.all([
-        Instance.findByContextVersionIdAsync(versionIds)
+        Instance.findByContextVersionIdsAsync(versionIds)
           .then(function updateCVsInAllInstances (instances) {
             return Promise.all(instances.map(function (instanceModel) {
               return instanceModel.updateCvAsync()

--- a/unit/models/mongo/instances.js
+++ b/unit/models/mongo/instances.js
@@ -631,7 +631,7 @@ describe('Instance Model Tests ' + moduleName, function () {
     })
   })
 
-  describe('findByContextVersionId', function () {
+  describe('findByContextVersionIds', function () {
     var instance = null
     var contextVersionId = newObjectId()
     beforeEach(function (done) {
@@ -650,19 +650,8 @@ describe('Instance Model Tests ' + moduleName, function () {
       var instance = createNewInstance('instance3', { contextVersion: { _id: contextVersionId } })
       instance.save(done)
     })
-    it('should pass a single contextVersion Id to find', function (done) {
-      Instance.findByContextVersionId(contextVersionId, function (err, results) {
-        expect(err).to.not.exist()
-        expect(results).to.be.an.array()
-        expect(results.length).to.equal(1)
-        expect(results[0]).to.be.an.object()
-        expect(results[0].name).to.equal('instance3')
-        expect(results[0].contextVersion._id.toString()).to.equal(contextVersionId.toString())
-        done()
-      })
-    })
     it('should pass the array of contextVersion Ids to find', function (done) {
-      Instance.findByContextVersionId([contextVersionId], function (err, results) {
+      Instance.findByContextVersionIds([contextVersionId], function (err, results) {
         expect(err).to.not.exist()
         expect(results).to.be.an.array()
         expect(results.length).to.equal(1)
@@ -673,7 +662,7 @@ describe('Instance Model Tests ' + moduleName, function () {
       })
     })
     it('should return an empty array if no contextVersions are found', function (done) {
-      Instance.findByContextVersionId([newObjectId()], function (err, results) {
+      Instance.findByContextVersionIds([newObjectId()], function (err, results) {
         expect(err).to.not.exist()
         expect(results).to.be.an.array()
         expect(results.length).to.equal(0)

--- a/unit/workers/on-image-builder-container-die.js
+++ b/unit/workers/on-image-builder-container-die.js
@@ -195,14 +195,14 @@ describe('OnImageBuilderContainerDie: ' + moduleName, function () {
       sinon.stub(ContextVersion, 'updateBuildCompletedByContainerAsync')
       sinon.stub(Build, 'updateFailedByContextVersionIds')
       sinon.stub(Build, 'updateCompletedByContextVersionIds')
-      sinon.stub(Instance, 'findByContextVersionIdAsync').resolves([ctx.instanceStub])
+      sinon.stub(Instance, 'findByContextVersionIdsAsync').resolves([ctx.instanceStub])
       done()
     })
     afterEach(function (done) {
       ContextVersion.updateBuildCompletedByContainerAsync.restore()
       Build.updateFailedByContextVersionIds.restore()
       Build.updateCompletedByContextVersionIds.restore()
-      Instance.findByContextVersionIdAsync.restore()
+      Instance.findByContextVersionIdsAsync.restore()
       done()
     })
     describe('success', function () {
@@ -214,8 +214,8 @@ describe('OnImageBuilderContainerDie: ' + moduleName, function () {
 
       it('it should handle successful build', function (done) {
         ctx.worker._handleBuildComplete(ctx.buildInfo, function () {
-          sinon.assert.calledOnce(Instance.findByContextVersionIdAsync)
-          sinon.assert.calledWith(Instance.findByContextVersionIdAsync, [ctx.mockContextVersion._id])
+          sinon.assert.calledOnce(Instance.findByContextVersionIdsAsync)
+          sinon.assert.calledWith(Instance.findByContextVersionIdsAsync, [ctx.mockContextVersion._id])
           sinon.assert.calledOnce(ctx.instanceStub.updateCvAsync)
           sinon.assert.calledWith(
             ContextVersion.updateBuildCompletedByContainerAsync,
@@ -247,8 +247,8 @@ describe('OnImageBuilderContainerDie: ' + moduleName, function () {
           it('it should handle failed build', function (done) {
             ctx.worker._handleBuildComplete(ctx.buildInfo, function (err) {
               if (err) { return done(err) }
-              sinon.assert.calledOnce(Instance.findByContextVersionIdAsync)
-              sinon.assert.calledWith(Instance.findByContextVersionIdAsync, [ctx.mockContextVersion._id])
+              sinon.assert.calledOnce(Instance.findByContextVersionIdsAsync)
+              sinon.assert.calledWith(Instance.findByContextVersionIdsAsync, [ctx.mockContextVersion._id])
               sinon.assert.calledOnce(ctx.instanceStub.updateCvAsync)
               sinon.assert.calledWith(
                 ContextVersion.updateBuildCompletedByContainerAsync,
@@ -272,8 +272,8 @@ describe('OnImageBuilderContainerDie: ' + moduleName, function () {
           })
           it('should callback the error', function (done) {
             ctx.worker._handleBuildComplete(ctx.buildInfo, function (err) {
-              sinon.assert.calledOnce(Instance.findByContextVersionIdAsync)
-              sinon.assert.calledWith(Instance.findByContextVersionIdAsync, [ctx.mockContextVersion._id])
+              sinon.assert.calledOnce(Instance.findByContextVersionIdsAsync)
+              sinon.assert.calledWith(Instance.findByContextVersionIdsAsync, [ctx.mockContextVersion._id])
               sinon.assert.calledOnce(ctx.instanceStub.updateCvAsync)
               expectErr(ctx.err, done)(err)
             })
@@ -288,7 +288,7 @@ describe('OnImageBuilderContainerDie: ' + moduleName, function () {
         })
         it('should callback the error', function (done) {
           ctx.worker._handleBuildComplete(ctx.buildInfo, function (err) {
-            sinon.assert.notCalled(Instance.findByContextVersionIdAsync)
+            sinon.assert.notCalled(Instance.findByContextVersionIdsAsync)
             sinon.assert.notCalled(ctx.instanceStub.updateCvAsync)
             expectErr(ctx.err, done)(err)
           })
@@ -303,8 +303,8 @@ describe('OnImageBuilderContainerDie: ' + moduleName, function () {
         })
         it('should callback the error', function (done) {
           ctx.worker._handleBuildComplete(ctx.buildInfo, function (err) {
-            sinon.assert.calledOnce(Instance.findByContextVersionIdAsync)
-            sinon.assert.calledWith(Instance.findByContextVersionIdAsync, [ctx.mockContextVersion._id])
+            sinon.assert.calledOnce(Instance.findByContextVersionIdsAsync)
+            sinon.assert.calledWith(Instance.findByContextVersionIdsAsync, [ctx.mockContextVersion._id])
             sinon.assert.calledOnce(ctx.instanceStub.updateCvAsync)
             expectErr(ctx.err, done)(err)
           })


### PR DESCRIPTION
By looking at the state of the instances in [this issue](https://runnable.atlassian.net/browse/SAN-3451) there was an obvious problem were instances had builds (the CV had a completed/not failed build), but the instances never got a container. By looking at the logs for some of these instances, we found that they stopped at `on-image-builder-container-die`. 

Looking closely at the code for `on-image-builder-container-die` we found that there were no errors for this worker, but that the next step was dependent on a query to the instances, which resulted empty. This seemed to be that the query was dependent on an update to the context version that had not been applied to the CV copy in the instance.

This PR fixes this by updating the CV in the instance after a necessary update has been made to it. It also throws an error and reports to Rollbar if no instances would be updated (which should never happen).
- [x] @podviaznikov
- [x] @anandkumarpatel 
### Tests

To test, just create a container a make sure it gets built. To test failure case, delete instance when it gets to `on-image-builder-container-die` and make sure it throws an error.
- [x] Tested on Gamma
- [x] Tested on Gamma again
