### PR TITLE
Split Notifications and Forking

### DIFF
--- a/lib/models/services/instance-fork-service.js
+++ b/lib/models/services/instance-fork-service.js
@@ -195,7 +195,6 @@ InstanceForkService._notifyExternalServices = function (data) {
  * 1 - Create a new Context Version
  * 2 - Create a new Build (and build it)
  * 3 - Fork the master Instance with the new Build
- * 4 - Notify external services about the new Instance
  * @private
  * @param {Object} instance Instance to Fork.
  * @param {Object} pushInfo GitHub push information.
@@ -204,7 +203,8 @@ InstanceForkService._notifyExternalServices = function (data) {
  * @param {String} pushInfo.commit GitHub Commit.
  * @param {Object} pushInfo.user GitHub User object.
  * @param {String} pushInfo.user.id GitHub User ID.
- * @returns {Promise} Resolved with new Instance.
+ * @returns {Promise} Resolves with [ forkedInstance, accessToken ] - access
+ *   token of the user used to create the instance (useful for notifications).
  */
 InstanceForkService._forkOne = function (instance, pushInfo) {
   var logData = {
@@ -268,20 +268,14 @@ InstanceForkService._forkOne = function (instance, pushInfo) {
               callback
             )
           })
-          // Errors from the above promise will be thrown and cause the
-          // notifications below to not be invoked (desired).
         })
-        // 4. notify any external services about the new update.
+        // Return the forked instance _and_ the access token of the user used to
+        // create it (useful for notifications)
         .then(function (forkedInstance) {
           var tokenLocation = 'accounts.github.accessToken'
           var accessToken = keypather.get(pushUser, tokenLocation) ||
             keypather.get(instanceUser, tokenLocation)
-          return InstanceForkService._notifyExternalServices({
-            instance: forkedInstance,
-            accessToken: accessToken,
-            pushInfo: pushInfo
-          })
-            .return(forkedInstance)
+          return [ forkedInstance, accessToken ]
         })
     })
     .catch(function (err) {
@@ -289,6 +283,46 @@ InstanceForkService._forkOne = function (instance, pushInfo) {
       throw err
     })
 }
+
+/**
+ * Fork an instance and notify external services.
+ * @private
+ * @param {Object} instance Instance to Fork.
+ * @param {Object} pushInfo GitHub push information.
+ * @param {String} pushInfo.repo GitHub Repository.
+ * @param {String} pushInfo.branch GitHub Branch.
+ * @param {String} pushInfo.commit GitHub Commit.
+ * @param {Object} pushInfo.user GitHub User object.
+ * @param {String} pushInfo.user.id GitHub User ID.
+ * @returns {Promise} Resolves with the forked instance.
+ */
+InstanceForkService._forkOneAndNotify = Promise.method(function (instance, pushInfo) {
+  var logData = {
+    tx: true,
+    instanceId: keypather.get(instance, '_id'),
+    pushInfo: pushInfo
+  }
+  log.info(logData, 'InstanceForkService._forkOneAndNotify')
+  if (!instance) {
+    throw new Error('_forkOneAndNotify instance is required')
+  }
+  if (!pushInfo) {
+    throw new Error('_forkOneAndNotify pushInfo is required')
+  }
+  return InstanceForkService._forkOne(instance, pushInfo)
+    .spread(function (forkedInstance, accessToken) {
+      return InstanceForkService._notifyExternalServices({
+        instance: forkedInstance,
+        accessToken: accessToken,
+        pushInfo: pushInfo
+      })
+        .return(forkedInstance)
+    })
+    .catch(function (err) {
+      log.error(assign({ err: err }, logData), 'InstanceForkService._forkOneAndNotify error')
+      throw err
+    })
+})
 
 /**
  * Create a new Context and ContextVersion for a given Context Version. This is
@@ -489,7 +523,7 @@ InstanceForkService.autoFork = function (instances, pushInfo) {
   })
     .then(function () {
       return Promise.map(instances, function (instance) {
-        return InstanceForkService._forkOne(instance, pushInfo)
+        return InstanceForkService._forkOneAndNotify(instance, pushInfo)
           .catch(function (err) {
             // log the error and return null
             var data = {
@@ -497,7 +531,7 @@ InstanceForkService.autoFork = function (instances, pushInfo) {
               instance: instance._id,
               pushInfo: pushInfo
             }
-            log.error(data, 'autoFork error from _forkOne')
+            log.error(data, 'autoFork error from _forkOneAndNotify')
             return null
           })
       })

--- a/unit/models/services/instance-fork-service.js
+++ b/unit/models/services/instance-fork-service.js
@@ -46,6 +46,14 @@ describe('InstanceForkService: ' + moduleName, function () {
       done()
     })
 
+    it('should require push info', function (done) {
+      InstanceForkService._validatePushInfo().asCallback(function (err) {
+        expect(err).to.exist()
+        expect(err.message).to.match(/requires.+pushInfo/i)
+        done()
+      })
+    })
+
     it('should require repo', function (done) {
       var info = omit(pushInfo, 'repo')
       InstanceForkService._validatePushInfo(info).asCallback(function (err) {
@@ -439,7 +447,6 @@ describe('InstanceForkService: ' + moduleName, function () {
       User.findByGithubId.withArgs('instanceCreatedById').yieldsAsync(null, mockInstanceUser)
       sinon.stub(InstanceForkService, '_createNewContextVersion').resolves(mockContextVersion)
       sinon.stub(Runnable, 'createClient').returns(mockRunnableClient)
-      sinon.stub(InstanceForkService, '_notifyExternalServices').resolves()
       done()
     })
 
@@ -449,7 +456,6 @@ describe('InstanceForkService: ' + moduleName, function () {
       User.findByGithubId.restore()
       InstanceForkService._createNewContextVersion.restore()
       Runnable.createClient.restore()
-      InstanceForkService._notifyExternalServices.restore()
       done()
     })
 
@@ -649,52 +655,26 @@ describe('InstanceForkService: ' + moduleName, function () {
       })
     })
 
-    it('should notify external services about the new instance', function (done) {
-      InstanceForkService._forkOne(instance, pushInfo).asCallback(function (err) {
-        expect(err).to.not.exist()
-        sinon.assert.calledOnce(InstanceForkService._notifyExternalServices)
-        sinon.assert.calledWithExactly(
-          InstanceForkService._notifyExternalServices,
-          {
-            instance: mockInstance,
-            accessToken: sinon.match.string,
-            pushInfo: pushInfo
-          }
-        )
-        done()
-      })
-    })
-
-    describe('access token used to notify', function (done) {
+    describe('the access token it returns', function (done) {
       it('should use the push user token by default', function (done) {
-        InstanceForkService._forkOne(instance, pushInfo).asCallback(function (err) {
+        InstanceForkService._forkOne(instance, pushInfo).asCallback(function (err, results) {
           expect(err).to.not.exist()
-          sinon.assert.calledOnce(InstanceForkService._notifyExternalServices)
-          sinon.assert.calledWithExactly(
-            InstanceForkService._notifyExternalServices,
-            {
-              instance: mockInstance,
-              accessToken: 'pushUserGithubToken',
-              pushInfo: pushInfo
-            }
-          )
+          expect(results).to.be.an.array()
+          expect(results).to.have.length(2)
+          var accessToken = results.pop()
+          expect(accessToken).to.equal('pushUserGithubToken')
           done()
         })
       })
 
       it('should use the instance user token if no push user token', function (done) {
         delete mockPushUser.accounts.github.accessToken
-        InstanceForkService._forkOne(instance, pushInfo).asCallback(function (err) {
+        InstanceForkService._forkOne(instance, pushInfo).asCallback(function (err, results) {
           expect(err).to.not.exist()
-          sinon.assert.calledOnce(InstanceForkService._notifyExternalServices)
-          sinon.assert.calledWithExactly(
-            InstanceForkService._notifyExternalServices,
-            {
-              instance: mockInstance,
-              accessToken: 'instanceUserGithubToken',
-              pushInfo: pushInfo
-            }
-          )
+          expect(results).to.be.an.array()
+          expect(results).to.have.length(2)
+          var accessToken = results.pop()
+          expect(accessToken).to.equal('instanceUserGithubToken')
           done()
         })
       })
@@ -709,17 +689,128 @@ describe('InstanceForkService: ' + moduleName, function () {
           User.findByGithubId,
           InstanceForkService._createNewContextVersion,
           mockRunnableClient.createAndBuildBuild,
-          mockRunnableClient.forkMasterInstance,
-          InstanceForkService._notifyExternalServices
+          mockRunnableClient.forkMasterInstance
         )
         done()
       })
     })
 
     it('should return the newly forked Instance', function (done) {
-      InstanceForkService._forkOne(instance, pushInfo).asCallback(function (err, newInstance) {
+      InstanceForkService._forkOne(instance, pushInfo).asCallback(function (err, results) {
         expect(err).to.not.exist()
+        expect(results).to.be.an.array()
+        expect(results).to.have.length(2)
+        var newInstance = results.shift()
         expect(newInstance).to.equal(mockInstance)
+        done()
+      })
+    })
+  })
+
+  describe('#_forkOneAndNotify', function () {
+    var instance
+    var pushInfo
+    var mockNewInstance = {}
+
+    beforeEach(function (done) {
+      instance = {
+        createdBy: {
+          github: 'instanceCreatedById'
+        },
+        owner: {
+          github: 'instanceOwnerId'
+        }
+      }
+      pushInfo = {
+        repo: 'mockRepo',
+        branch: 'mockBranch',
+        commit: 'mockCommit',
+        user: {
+          id: 'pushUserId'
+        }
+      }
+      sinon.stub(InstanceForkService, '_forkOne').resolves([ mockNewInstance, 'mockAccessToken' ])
+      sinon.stub(InstanceForkService, '_notifyExternalServices').resolves(mockNewInstance)
+      done()
+    })
+
+    afterEach(function (done) {
+      InstanceForkService._forkOne.restore()
+      InstanceForkService._notifyExternalServices.restore()
+      done()
+    })
+
+    describe('errors', function () {
+      it('should require an instance', function (done) {
+        InstanceForkService._forkOneAndNotify().asCallback(function (err) {
+          expect(err).to.exist()
+          expect(err.message).to.match(/instance.+required/i)
+          done()
+        })
+      })
+
+      it('should require push info', function (done) {
+        InstanceForkService._forkOneAndNotify(instance).asCallback(function (err) {
+          expect(err).to.exist()
+          expect(err.message).to.match(/pushInfo.+required/i)
+          done()
+        })
+      })
+
+      it('should reject with any _forkOne error', function (done) {
+        var error = new Error('robot')
+        InstanceForkService._forkOne.rejects(error)
+        InstanceForkService._forkOneAndNotify(instance, pushInfo).asCallback(function (err) {
+          expect(err).to.exist()
+          expect(err).to.equal(error)
+          done()
+        })
+      })
+
+      it('should reject with any notify external services error', function (done) {
+        var error = new Error('robot')
+        InstanceForkService._notifyExternalServices.rejects(error)
+        InstanceForkService._forkOneAndNotify(instance, pushInfo).asCallback(function (err) {
+          expect(err).to.exist()
+          expect(err).to.equal(error)
+          done()
+        })
+      })
+    })
+
+    it('should _forkOne our instance', function (done) {
+      InstanceForkService._forkOneAndNotify(instance, pushInfo).asCallback(function (err) {
+        expect(err).to.not.exist()
+        sinon.assert.calledOnce(InstanceForkService._forkOne)
+        sinon.assert.calledWithExactly(
+          InstanceForkService._forkOne,
+          instance,
+          pushInfo
+        )
+        done()
+      })
+    })
+
+    it('should notify external services', function (done) {
+      InstanceForkService._forkOneAndNotify(instance, pushInfo).asCallback(function (err) {
+        expect(err).to.not.exist()
+        sinon.assert.calledOnce(InstanceForkService._notifyExternalServices)
+        sinon.assert.calledWithExactly(
+          InstanceForkService._notifyExternalServices,
+          {
+            instance: mockNewInstance,
+            accessToken: sinon.match.string,
+            pushInfo: pushInfo
+          }
+        )
+        done()
+      })
+    })
+
+    it('should return our new instance', function (done) {
+      InstanceForkService._forkOneAndNotify(instance, pushInfo).asCallback(function (err, instance) {
+        expect(err).to.not.exist()
+        expect(instance).to.equal(mockNewInstance)
         done()
       })
     })
@@ -1193,7 +1284,7 @@ describe('InstanceForkService: ' + moduleName, function () {
     })
   })
 
-  describe('#autoFork Instances', function () {
+  describe('#autoFork', function () {
     var instances
     var pushInfo = {}
     var mockTimer
@@ -1203,7 +1294,7 @@ describe('InstanceForkService: ' + moduleName, function () {
       mockTimer = {
         stop: sinon.stub()
       }
-      sinon.stub(InstanceForkService, '_forkOne').resolves({})
+      sinon.stub(InstanceForkService, '_forkOneAndNotify').resolves({})
       sinon.stub(monitorDog, 'increment')
       sinon.stub(monitorDog, 'timer').returns(mockTimer)
       sinon.stub(Bunyan.prototype, 'error')
@@ -1211,7 +1302,7 @@ describe('InstanceForkService: ' + moduleName, function () {
     })
 
     afterEach(function (done) {
-      InstanceForkService._forkOne.restore()
+      InstanceForkService._forkOneAndNotify.restore()
       monitorDog.increment.restore()
       monitorDog.timer.restore()
       Bunyan.prototype.error.restore()
@@ -1223,7 +1314,7 @@ describe('InstanceForkService: ' + moduleName, function () {
         InstanceForkService.autoFork('').asCallback(function (err) {
           expect(err).to.exist()
           expect(err.message).to.match(/instances.+array/i)
-          sinon.assert.notCalled(InstanceForkService._forkOne)
+          sinon.assert.notCalled(InstanceForkService._forkOneAndNotify)
           done()
         })
       })
@@ -1232,7 +1323,7 @@ describe('InstanceForkService: ' + moduleName, function () {
         InstanceForkService.autoFork(instances).asCallback(function (err) {
           expect(err).to.exist()
           expect(err.message).to.match(/autoFork.+requires.+pushInfo/i)
-          sinon.assert.notCalled(InstanceForkService._forkOne)
+          sinon.assert.notCalled(InstanceForkService._forkOneAndNotify)
           done()
         })
       })
@@ -1241,7 +1332,7 @@ describe('InstanceForkService: ' + moduleName, function () {
     it('should not fork anything with an empty array', function (done) {
       InstanceForkService.autoFork(instances, pushInfo).asCallback(function (err) {
         expect(err).to.not.exist()
-        sinon.assert.notCalled(InstanceForkService._forkOne)
+        sinon.assert.notCalled(InstanceForkService._forkOneAndNotify)
         done()
       })
     })
@@ -1263,9 +1354,9 @@ describe('InstanceForkService: ' + moduleName, function () {
       instances.push(i)
       InstanceForkService.autoFork(instances, pushInfo).asCallback(function (err) {
         expect(err).to.not.exist()
-        sinon.assert.calledOnce(InstanceForkService._forkOne)
+        sinon.assert.calledOnce(InstanceForkService._forkOneAndNotify)
         sinon.assert.calledWithExactly(
-          InstanceForkService._forkOne,
+          InstanceForkService._forkOneAndNotify,
           i,
           pushInfo
         )
@@ -1277,18 +1368,18 @@ describe('InstanceForkService: ' + moduleName, function () {
       var one = {}
       var two = {}
       instances.push(one, two)
-      InstanceForkService._forkOne.onFirstCall().resolves(1)
-      InstanceForkService._forkOne.onSecondCall().resolves(2)
+      InstanceForkService._forkOneAndNotify.onFirstCall().resolves(1)
+      InstanceForkService._forkOneAndNotify.onSecondCall().resolves(2)
       InstanceForkService.autoFork(instances, pushInfo).asCallback(function (err, results) {
         expect(err).to.not.exist()
-        sinon.assert.calledTwice(InstanceForkService._forkOne)
+        sinon.assert.calledTwice(InstanceForkService._forkOneAndNotify)
         sinon.assert.calledWithExactly(
-          InstanceForkService._forkOne,
+          InstanceForkService._forkOneAndNotify,
           one,
           pushInfo
         )
         sinon.assert.calledWithExactly(
-          InstanceForkService._forkOne,
+          InstanceForkService._forkOneAndNotify,
           two,
           pushInfo
         )
@@ -1300,8 +1391,8 @@ describe('InstanceForkService: ' + moduleName, function () {
     it('should silence any errors from forking', function (done) {
       instances.push({}, {})
       var error = new Error('robot')
-      InstanceForkService._forkOne.onFirstCall().resolves(1)
-      InstanceForkService._forkOne.onSecondCall().rejects(error)
+      InstanceForkService._forkOneAndNotify.onFirstCall().resolves(1)
+      InstanceForkService._forkOneAndNotify.onSecondCall().rejects(error)
       InstanceForkService.autoFork(instances, pushInfo).asCallback(function (err, results) {
         expect(err).to.not.exist()
         expect(results).to.deep.equal([ 1, null ])
@@ -1323,8 +1414,8 @@ describe('InstanceForkService: ' + moduleName, function () {
         sinon.assert.called(mockTimer.stop)
         sinon.assert.callOrder(
           monitorDog.timer,
-          InstanceForkService._forkOne,
-          InstanceForkService._forkOne,
+          InstanceForkService._forkOneAndNotify,
+          InstanceForkService._forkOneAndNotify,
           mockTimer.stop
         )
         done()


### PR DESCRIPTION
Basically, I don't want the fork logic to notify external services. That should be the job of whatever is calling fork in the first place (which is, conveniently, in this file).

This is pretty much a small amount of cleanup, so there shouldn't be anything crazy. Unit tests have been updated.
### Reviewer(s)
- [x] @podviaznikov
