### PR TITLE
Fix bug with handling error case when container was changed

### DIFF
--- a/lib/models/mongo/instance.js
+++ b/lib/models/mongo/instance.js
@@ -368,11 +368,6 @@ InstanceSchema.statics.findOneStopping = function (instanceId, containerId, cb) 
       log.error(logData, 'findOneStopping failed to find/mark instance as stopping')
       return cb(err)
     }
-    if (!instance) {
-      var notFound = Boom.badRequest('Instance container has changed')
-      log.trace(logData, 'findOneStopping instance already changed state')
-      return cb(notFound)
-    }
     log.trace(put({
       containerState: keypather.get(instance, 'container.inspect.State')
     }, logData), 'findOneStopping instance was updated')
@@ -445,11 +440,6 @@ InstanceSchema.statics.findOneStarting = function (instanceId, containerId, cb) 
     if (err) {
       log.error(logData, 'findOneStarting failed to find/mark instance as stopping')
       return cb(err)
-    }
-    if (!instance) {
-      var notFound = Boom.badRequest('Instance container has changed')
-      log.trace(logData, 'findOneStarting instance already changed state')
-      return cb(notFound)
     }
     log.trace(put({
       containerState: keypather.get(instance, 'container.inspect.State')

--- a/unit/models/mongo/instances.js
+++ b/unit/models/mongo/instances.js
@@ -135,10 +135,11 @@ describe('Instance Model Tests ' + moduleName, function () {
         done()
       })
     })
-    it('should return an error if instance was not found', function (done) {
+    it('should return null if instance was not found', function (done) {
       Instance.findOne.yieldsAsync(null, null)
       Instance.findOneStarting(mockInstance._id, 'container-id', function (err, instance) {
-        expect(err.message).to.equal('Instance container has changed')
+        expect(err).to.not.exist()
+        expect(instance).to.be.null()
         sinon.assert.calledOnce(Instance.findOne)
         done()
       })
@@ -234,10 +235,11 @@ describe('Instance Model Tests ' + moduleName, function () {
         done()
       })
     })
-    it('should return an error if instance was not found', function (done) {
+    it('should return null if instance was not found', function (done) {
       Instance.findOne.yieldsAsync(null, null)
       Instance.findOneStopping(mockInstance._id, 'container-id', function (err, instance) {
-        expect(err.message).to.equal('Instance container has changed')
+        expect(err).to.not.exist()
+        expect(instance).to.be.null()
         sinon.assert.calledOnce(Instance.findOne)
         done()
       })


### PR DESCRIPTION
Fix bug with handling error case when conatiner was changed
- Remove callbacking with an error if instance wasn't found. The case when instance wasn't found is handled already in the worker. And it throws TaskFatalError there
### Reviewers
- [x] @anandkumarpatel 
### Tests
- [x] test on staging
