### PR TITLE
SAN-3722 - Fix deployed link in github

### DIFF
--- a/configs/.env.production-delta
+++ b/configs/.env.production-delta
@@ -14,5 +14,6 @@ GITHUB_DEPLOY_KEYS_POOL_SIZE=100
 LOG_LEVEL_STDOUT=trace
 S3_CONTEXT_RESOURCE_BUCKET=runnable.context.resources.production
 VALID_REDIR_TLDS=runnable.io,runnableapp.com
+WEB_URL=https://app.runnable.io
 # used by new relic npm module
 NEW_RELIC_TRACER_ENABLED=false

--- a/configs/.env.production-epsilon
+++ b/configs/.env.production-epsilon
@@ -19,3 +19,4 @@ NEW_RELIC_TRACER_ENABLED=false
 REGISTRY_DOMAIN=registry.runnable.com
 S3_CONTEXT_RESOURCE_BUCKET=runnable.context.resources.production-beta
 VALID_REDIR_TLDS=runnable-beta.io,runnablecloud.com
+WEB_URL=https://app.runnable-beta.com

--- a/configs/.env.production-gamma
+++ b/configs/.env.production-gamma
@@ -19,3 +19,4 @@ NEW_RELIC_TRACER_ENABLED=false
 REGISTRY_DOMAIN=registry.runnable.com
 S3_CONTEXT_RESOURCE_BUCKET=runnable.context.resources.production-beta
 VALID_REDIR_TLDS=runnable-gamma.com,runnable.ninja
+WEB_URL=https://app.runnable-gamma.com

--- a/configs/.env.staging
+++ b/configs/.env.staging
@@ -39,3 +39,4 @@ ROLLBAR_KEY=a90d9c262c7c48cfabbd32fd0a1bc61c
 S3_CONTEXT_RESOURCE_BUCKET=runnable.context.resources.development
 USER_CONTENT_DOMAIN=runnable2.net
 ALLOW_ALL_CORS=true
+WEB_URL=https://runnable-angular-staging-codenow.runnableapp.com

--- a/configs/.env.test
+++ b/configs/.env.test
@@ -41,6 +41,7 @@ SWARM_HOST=http://localhost:4243
 TOKEN_EXPIRES=5 minutes
 USER_CONTENT_DOMAIN=runnableapp.com
 VALID_REDIR_TLDS=runnableapp.com,domains.net
+WEB_URL=https://web.runnable.dev
 
 # used by docker listener
 DISABLE_RANDOM_EVENTS=true

--- a/lib/models/apis/pullrequest.js
+++ b/lib/models/apis/pullrequest.js
@@ -105,5 +105,5 @@ PullRequest.prototype._deploymentStatus = function (gitInfo, deploymentId, state
 
 function createTargetUrl (instance) {
   var owner = keypather.get(instance, 'owner.username')
-  return 'https://' + process.env.DOMAIN + '/' + owner + '/' + instance.name
+  return process.env.WEB_URL + '/' + owner + '/' + instance.name
 }

--- a/unit/models/apis/pullrequest.js
+++ b/unit/models/apis/pullrequest.js
@@ -98,7 +98,7 @@ describe('PullRequest: ' + moduleName, function () {
         expect(repo).to.equal(gitInfo.repo)
         expect(payload.id).to.equal('deployment-id')
         expect(payload.state).to.equal('success')
-        expect(payload.target_url).to.equal('https://' + process.env.DOMAIN + '/codenow/inst-1')
+        expect(payload.target_url).to.equal(process.env.WEB_URL + '/codenow/inst-1')
         expect(payload.description).to.equal('Deployed to inst-1 on Runnable.')
         GitHub.prototype.createDeploymentStatus.restore()
         PullRequest.prototype.createDeployment.restore()


### PR DESCRIPTION
- I updated the deployed link to point to app.runnable.io instead of runnable.io
### Dependencies

None
### Reviewers
- [x] @podviaznikov
- [x] @Nathan219
### Tests
- [x] Make a pull request, make a change, wait for deployment message and verify the link in github works
### Integration Test

Please follow the guidelines presented in the [How to Test an API PR](https://github.com/CodeNow/devops-scripts/wiki/How-to-Test-an-API-Pull-Request)
article when setting-up and performing tests.
- [x] Integration Tested @ commitsh by person_3 on (gamma|epsilon|staging)
