### PR TITLE
Also return github org when querying whitelisted orgs

### DIFF
--- a/lib/models/mongo/user-whitelist.js
+++ b/lib/models/mongo/user-whitelist.js
@@ -14,7 +14,7 @@ var UserWhitelistSchema = require('models/mongo/schemas/user-whitelist')
  * @param {String} accessToken - A Github access token to get user orgs
  * @param {Function} cb
  */
-UserWhitelistSchema.statics.getUserWhitelistedOrgs = function (accessToken, cb) {
+UserWhitelistSchema.statics.getWhitelistedUsersForGithubUser = function (accessToken, cb) {
   var self = this
   if (!accessToken) {
     return cb(new Error('An access token must be provided'))

--- a/lib/routes/auth/whitelist.js
+++ b/lib/routes/auth/whitelist.js
@@ -24,7 +24,7 @@ app.all('/auth/whitelist*',
  *  @event GET rest/auth/whitelist/
  *  @memberof module:lib/routes/auth/whitelist */
 app.get('/auth/whitelist/',
-  userWhitelist.getUserWhitelistedOrgs('sessionUser.accounts.github.accessToken'),
+  userWhitelist.getWhitelistedUsersForGithubUser('sessionUser.accounts.github.accessToken'),
   checkFound('userwhitelists'),
   mw.res.json(200, 'userwhitelists'))
 

--- a/unit/models/mongo/user-whitelist.js
+++ b/unit/models/mongo/user-whitelist.js
@@ -58,9 +58,9 @@ describe('UserWhitelist: ' + moduleName, function () {
     done()
   })
 
-  describe('getUserWhitelistedOrgs', function () {
+  describe('getWhitelistedUsersForGithubUser', function () {
     it('should get all orgs that GH authorizes the user to see', function (done) {
-      UserWhitelist.getUserWhitelistedOrgs(accessToken, function (err, orgs) {
+      UserWhitelist.getWhitelistedUsersForGithubUser(accessToken, function (err, orgs) {
         if (err) done(err)
         sinon.assert.calledOnce(Github.prototype.getUserAuthorizedOrgs)
         sinon.assert.calledOnce(UserWhitelist.find)
@@ -80,7 +80,7 @@ describe('UserWhitelist: ' + moduleName, function () {
     })
 
     it('should get return the github orgs as part of the object', function (done) {
-      UserWhitelist.getUserWhitelistedOrgs(accessToken, function (err, orgs) {
+      UserWhitelist.getWhitelistedUsersForGithubUser(accessToken, function (err, orgs) {
         if (err) done(err)
         expect(err).to.not.exist()
         expect(orgs).to.be.an.array()
@@ -97,7 +97,7 @@ describe('UserWhitelist: ' + moduleName, function () {
       }])
       UserWhitelist.find.yieldsAsync(null, [])
 
-      UserWhitelist.getUserWhitelistedOrgs(accessToken, function (err, orgs) {
+      UserWhitelist.getWhitelistedUsersForGithubUser(accessToken, function (err, orgs) {
         if (err) done(err)
         sinon.assert.calledOnce(Github.prototype.getUserAuthorizedOrgs)
         sinon.assert.calledOnce(UserWhitelist.find)
@@ -117,7 +117,7 @@ describe('UserWhitelist: ' + moduleName, function () {
 
     it('should throw an error if it cant get the authorized orgs from GH', function (done) {
       Github.prototype.getUserAuthorizedOrgs.yieldsAsync(new Error('could not fetch github error'), null)
-      UserWhitelist.getUserWhitelistedOrgs(accessToken, function (err, orgs) {
+      UserWhitelist.getWhitelistedUsersForGithubUser(accessToken, function (err, orgs) {
         expect(err).to.exist()
         expect(err.message).to.match(/github.*error/i)
         expect(orgs).to.not.exist()
@@ -126,7 +126,7 @@ describe('UserWhitelist: ' + moduleName, function () {
     })
 
     it('should throw an error if no acess token is provided', function (done) {
-      UserWhitelist.getUserWhitelistedOrgs(null, function (err, orgs) {
+      UserWhitelist.getWhitelistedUsersForGithubUser(null, function (err, orgs) {
         expect(err).to.exist()
         expect(err.message).to.match(/access.*token.*provided/i)
         expect(orgs).to.not.exist()


### PR DESCRIPTION
- Added github org to whitelist response

This allows us to not have to make another extra API call in the frontend, since very time you query the whitelisted orgs you basically also want the Github org object too.
### Reviewers
- [x] @podviaznikov
- [x] @Nathan219 
### Integration Test

Please follow the guidelines presented in the [How to Test an API PR](https://github.com/CodeNow/devops-scripts/wiki/How-to-Test-an-API-Pull-Request)
article when setting-up and performing tests.
- [x] Integration Tested @ 0b9a007db90eb586b4d46a72440d9060093aabfe by Nathan219 on staging
