### PR TITLE
SAN-3737 - Send warning on 4xx errors

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -93,7 +93,7 @@ function report (err) {
     custom: custom
   }
   if (error.is4XX(err)) {
-    payload.level = 'warning';
+    payload.level = 'warning'
   }
   if (custom.level) {
     payload.level = custom.level


### PR DESCRIPTION
- Updated so we log 4xx errors as warnings instead of error.
### Dependencies

None
### Reviewers
- [x] @Nathan219
- [x] @podviaznikov
### Tests
- [x] Cause a 400+ error (ignore 401, we don't report those) and see that it was reported as a warning instead of an error to rollbar.
### Integration Test

Please follow the guidelines presented in the [How to Test an API PR](https://github.com/CodeNow/devops-scripts/wiki/How-to-Test-an-API-Pull-Request)
article when setting-up and performing tests.
- [x] Integration Tested @ commitsh by person_3 on (gamma|epsilon|staging)
