### PR TITLE
Stop printing the build log out

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -102,13 +102,16 @@ var serializers = put(bunyan.stdSerializers, {
     return _removeExtraKeys(data)
   },
   contextVersion: function (data) {
-    return _removeExtraKeys(data)
+    return pick(data, ['_id', 'build._id', 'build.dockerContainer', 'build.completed', 'build.started'])
   },
   update: function (data) {
     return _removeExtraKeys(data)
   },
   contextVersions: function (data) {
-    return _removeExtraKeys(data)
+    if (Array.isArray(data)) {
+      return data.map(serializers.contextVersion)
+    }
+    return serializers.contextVersion(data)
   }
 })
 

--- a/lib/models/mongo/context-version.js
+++ b/lib/models/mongo/context-version.js
@@ -47,7 +47,7 @@ var dateLTE = function (d1, d2) {
 function emitIfCompleted (cv) {
   log.trace({
     tx: true,
-    cv: cv._id
+    contextVersion: cv
   }, 'emitIfCompleted')
   if (cv.build.completed) {
     log.trace({tx: true}, 'emitIfCompleted completed true')

--- a/lib/models/mongo/schemas/build.js
+++ b/lib/models/mongo/schemas/build.js
@@ -10,12 +10,10 @@
 var extend = require('extend')
 var mongoose = require('mongoose')
 var BaseSchema = require('models/mongo/schemas/base')
-var logger = require('middlewares/logger')(__filename)
 var validators = require('models/mongo/schemas/schema-validators').commonValidators
 
 var ObjectId = mongoose.Schema.ObjectId
 var Schema = mongoose.Schema
-var log = logger.log
 
 /** @alias module:models/version */
 var BuildSchema = module.exports = new Schema({
@@ -104,31 +102,6 @@ extend(BuildSchema.methods, BaseSchema.methods)
 extend(BuildSchema.statics, BaseSchema.statics)
 
 BuildSchema.set('toJSON', { virtuals: true })
-// BuildSchema.post('init', function (doc) {
-//  console.log('** BUILD *** %s has been initialized from the db', doc)
-// })
-BuildSchema.pre('validate', function (next) {
-  // Do validation here
-  next()
-})
-BuildSchema.post('validate', function (doc) {
-  log.trace({
-    tx: true,
-    doc: doc
-  }, 'build validated not yet saved')
-})
-BuildSchema.post('save', function (doc) {
-  log.trace({
-    tx: true,
-    doc: doc
-  }, 'build saved')
-})
-BuildSchema.post('remove', function (doc) {
-  log.trace({
-    tx: true,
-    doc: doc
-  }, 'build removed')
-})
 
 function numberRequirement (key) { return key && key.github && typeof key.github === 'number' }
 BuildSchema.path('createdBy').validate(numberRequirement, 'Invalid CreatedBy')

--- a/lib/models/mongo/schemas/context-version.js
+++ b/lib/models/mongo/schemas/context-version.js
@@ -12,12 +12,10 @@ var mongoose = require('mongoose')
 
 var AppCodeVersionSchema = require('models/mongo/schemas/app-code-version')
 var BaseSchema = require('models/mongo/schemas/base')
-var logger = require('middlewares/logger')(__filename)
 var validators = require('models/mongo/schemas/schema-validators').commonValidators
 
 var ObjectId = mongoose.Schema.ObjectId
 var Schema = mongoose.Schema
-var log = logger.log
 
 /** @alias module:models/version */
 var ContextVersionSchema = module.exports = new Schema({
@@ -273,22 +271,3 @@ ContextVersionSchema.virtual('build.duration').get(function () {
 
 function numberRequirement (key) { return key && key.github && typeof key.github === 'number' }
 ContextVersionSchema.path('createdBy').validate(numberRequirement, 'Invalid CreatedBy')
-
-ContextVersionSchema.post('validate', function (doc) {
-  log.trace({
-    tx: true,
-    modelId: doc._id
-  }, 'version validated not saved yet')
-})
-ContextVersionSchema.post('save', function (doc) {
-  log.trace({
-    tx: true,
-    modelId: doc._id
-  }, 'version saved')
-})
-ContextVersionSchema.post('remove', function (doc) {
-  log.trace({
-    tx: true,
-    modelId: doc._id
-  }, 'version removed')
-})

--- a/lib/models/mongo/schemas/instance.js
+++ b/lib/models/mongo/schemas/instance.js
@@ -9,11 +9,9 @@ var mongoose = require('mongoose')
 
 var BaseSchema = require('models/mongo/schemas/base')
 var validators = require('models/mongo/schemas/schema-validators').commonValidators
-var logger = require('middlewares/logger')(__filename)
 
 var ObjectId = mongoose.Schema.ObjectId
 var Schema = mongoose.Schema
-var log = logger.log
 
 /** @alias module:models/instance */
 var InstanceSchema = module.exports = new Schema({
@@ -282,31 +280,6 @@ InstanceSchema.index({
 
 extend(InstanceSchema.methods, BaseSchema.methods)
 extend(InstanceSchema.statics, BaseSchema.statics)
-// InstanceSchema.post('init', function (doc) {
-//  console.log('*** INSTANCE ****  %s has been initialized from the db', doc)
-// })
-InstanceSchema.pre('validate', function (next) {
-  // Do validation here
-  next()
-})
-InstanceSchema.post('validate', function (doc) {
-  log.trace({
-    tx: true,
-    modelId: doc._id
-  }, 'instance validated not saved')
-})
-InstanceSchema.post('save', function (doc) {
-  log.trace({
-    tx: true,
-    modelId: doc._id
-  }, 'instance saved')
-})
-InstanceSchema.post('remove', function (doc) {
-  log.trace({
-    tx: true,
-    modelId: doc._id
-  }, 'instance removed')
-})
 
 function numberRequirement (key) { return key && key.github && typeof key.github === 'number' }
 InstanceSchema.path('owner').validate(numberRequirement, 'Invalid Owner Id for Instance')


### PR DESCRIPTION
Get rid of this line that prints out the entire build log!
### Dependencies

None
### Reviewers
- [x] @podviaznikov
- [x] @thejsj
### Tests
- [x] Run this as the worker.  You should not see the your cmd logs get flooded by a build log
### Integration Test

Please follow the guidelines presented in the [How to Test an API PR](https://github.com/CodeNow/devops-scripts/wiki/How-to-Test-an-API-Pull-Request)
article when setting-up and performing tests.
- [x] Integration Tested @ abc0dce41963988c9786faad4de8ff4d68eaf434 by @thejsj on gamma
