### PR TITLE
Remove duplicate code for the docker container operations and add datadog counters

### DIFF
--- a/lib/models/apis/docker.js
+++ b/lib/models/apis/docker.js
@@ -903,7 +903,7 @@ Docker.prototype.execContainer = function (containerId, cb) {
 
 /**
  * Function to perform docker action on the Container
- * It also reports data to the datadog (count events and run timer) and logs response.
+ * It also reports data to the datadog (count events) and logs response.
  * @param {String} containerId - Container ID
  * @param {String} action - Docker operation like `start`, `logs`, `exec` etc
  * @param {Object} opts - options to pass for the Docker action
@@ -918,14 +918,10 @@ Docker.prototype._containerAction = function (containerId, action, opts, cb) {
   }
   var log = logger.log.child(logData)
   monitor.increment('api.docker.call.' + action)
-  var timer = monitor.timer('api.docker.container.' + action, true)
-  var failedTimer = monitor.timer('api.docker.container.failed.' + action, true)
   var start = new Date()
   var container = this.docker.getContainer(containerId)
   container[action](opts, function (err, response) {
-    timer.stop()
     if (err) {
-      failedTimer.stop()
       monitor.increment('api.docker.call.failure.' + action, 1, [
         'code:' + err.statusCode
       ])

--- a/unit/models/apis/docker.js
+++ b/unit/models/apis/docker.js
@@ -1294,15 +1294,7 @@ describe('docker: ' + moduleName, function () {
     beforeEach(function (done) {
       sinon.stub(Dockerode.prototype, 'getContainer')
       sinon.stub(monitor, 'increment')
-      sinon.stub(monitor, 'timer')
       sinon.spy(model, 'handleErr')
-      ctx.timer = {
-        stop: function () {
-          return
-        }
-      }
-      monitor.timer.returns(ctx.timer)
-      sinon.spy(ctx.timer, 'stop')
       done()
     })
 
@@ -1310,8 +1302,6 @@ describe('docker: ' + moduleName, function () {
       Dockerode.prototype.getContainer.restore()
       model.handleErr.restore()
       monitor.increment.restore()
-      monitor.timer.restore()
-      ctx.timer.stop.restore()
       done()
     })
 
@@ -1346,18 +1336,6 @@ describe('docker: ' + moduleName, function () {
           expect(resp).to.equal(ctx.opResp)
           sinon.assert.calledOnce(monitor.increment)
           sinon.assert.calledWith(monitor.increment, 'api.docker.call.exec')
-          done()
-        })
-      })
-
-      it('should time action using monitor', function (done) {
-        model._containerAction('_container_id_', 'exec', ctx.opOpts, function (err, resp) {
-          if (err) { return done(err) }
-          expect(resp).to.equal(ctx.opResp)
-          sinon.assert.calledTwice(monitor.timer)
-          sinon.assert.calledWith(monitor.timer, 'api.docker.container.exec', true)
-          sinon.assert.calledWith(monitor.timer, 'api.docker.container.failed.exec', true)
-          sinon.assert.calledOnce(ctx.timer.stop)
           done()
         })
       })
@@ -1398,18 +1376,6 @@ describe('docker: ' + moduleName, function () {
           sinon.assert.calledTwice(monitor.increment)
           sinon.assert.calledWith(monitor.increment, 'api.docker.call.exec')
           sinon.assert.calledWith(monitor.increment, 'api.docker.call.failure.exec', 1)
-          done()
-        })
-      })
-
-      it('should time action using monitor', function (done) {
-        model._containerAction('_container_id_', 'exec', ctx.opOpts, function (err, resp) {
-          expect(err).to.exist()
-          expect(resp).to.equal(ctx.opResp)
-          sinon.assert.calledTwice(monitor.timer)
-          sinon.assert.calledWith(monitor.timer, 'api.docker.container.exec', true)
-          sinon.assert.calledWith(monitor.timer, 'api.docker.container.failed.exec', true)
-          sinon.assert.calledTwice(ctx.timer.stop)
           done()
         })
       })


### PR DESCRIPTION
# Remove duplicate code for the docker container operations and use common code
- make one function that handle docker container operation
- now this common function counts actions in datadog, logs errors and response
### Dependencies
- [x] list dependencies (eg, PR from another branch or repo; tags or versions required prior to deployment)
### Reviewers
- [x] @thejsj
- [x] @myztiq
### Tests
- [x] Additional test...
### Integration Test

Please follow the guidelines presented in the [How to Test an API PR](https://github.com/CodeNow/devops-scripts/wiki/How-to-Test-an-API-Pull-Request)
article when setting-up and performing tests.
- [x] Integration Tested @ commitsh by person_3 on (gamma|epsilon|staging)
