### PR TITLE
Fix race condition in tests

### DIFF
--- a/test/functional/actions-github.js
+++ b/test/functional/actions-github.js
@@ -615,10 +615,23 @@ describe('Github - /actions/github', function () {
       })
 
       describe('with two instances', function () {
+        var stopListeningToBuildRunning
         beforeEach(function (done) {
           var count = createCount(2, done)
           ctx.instance2 = ctx.user.copyInstance(ctx.instance.attrs.shortHash, {}, count.next)
           primus.expectActionCount('start', 1, count.next)
+        })
+        beforeEach(function (done) {
+          // Emit build complete for all `build_running` containers
+          stopListeningToBuildRunning = primus.listenToAction('build_running', function (err, actionData) {
+            if (err) return err
+            dockerMockEvents.emitBuildComplete(actionData.data.data)
+          })
+          done()
+        })
+        afterEach(function (done) {
+          stopListeningToBuildRunning()
+          done()
         })
 
         it('should redeploy two instances with new build', function (done) {
@@ -634,7 +647,6 @@ describe('Github - /actions/github', function () {
           var options = hooks(data).push
           options.json.created = false
           var username = user.login
-
           require('./fixtures/mocks/github/users-username')(user.id, username)
           require('./fixtures/mocks/github/user')(username)
 
@@ -654,9 +666,9 @@ describe('Github - /actions/github', function () {
               'contextVersion.build.triggeredAction.appCodeVersion.repo': options.json.repository.full_name,
               'contextVersion.build.triggeredAction.appCodeVersion.commit': options.json.head_commit.id
             }
-            expect(successStub.calledTwice).to.equal(true)
-            expect(slackStub.calledOnce).to.equal(true)
-            expect(slackStub.calledWith(sinon.match.object, sinon.match.array)).to.equal(true)
+            sinon.assert.calledTwice(successStub)
+            sinon.assert.calledOnce(slackStub)
+            sinon.assert.calledWith(slackStub, sinon.match.object, sinon.match.array)
             ctx.instance.fetch(expects.success(200, expected, function (err) {
               if (err) { return done(err) }
               ctx.instance2.fetch(expects.success(200, expected, function () {
@@ -672,7 +684,6 @@ describe('Github - /actions/github', function () {
             expect(cvIds).to.exist()
             expect(cvIds).to.be.an.array()
             expect(cvIds).to.have.length(2)
-            finishAllIncompleteVersions()
           })
         })
       })

--- a/test/functional/fixtures/primus.js
+++ b/test/functional/fixtures/primus.js
@@ -77,6 +77,23 @@ module.exports = {
       }
     })
   },
+  listenToAction: function (action, cb) {
+    log.trace({expectedAction: action}, 'listenToAction')
+    function listenToAction (data) {
+      log.trace('primus expect:',
+        'ROOM_MESSAGE', action,
+        data.event, data.data.action)
+      if (data.event === 'ROOM_MESSAGE' && data.data.action === action) {
+        log.trace('primus expected data:', data.data.data)
+        cb(null, data)
+      }
+    }
+    if (!ctx.primus) { return cb(new Error('can not primus.expectAction if not connected')) }
+    ctx.primus.on('data', listenToAction)
+    return function () {
+      ctx.primus.removeListener('data', listenToAction)
+    }
+  },
   expectAction: function (action, expected, cb) {
     log.trace({expectedAction: action}, 'expectAction')
     if (isFunction(expected)) {


### PR DESCRIPTION
Noticed this test was inconsistently succeeding and starting digging into the test. Founds this.
- Fix race condition in tests that started listening to event (`build_running`) after the event might have been possibly fired.
### Reviewers
- [x] @podviaznikov
### Tests
- [x] Run old test a bunch of times, possibly with a lot of logs. Assert it fails at least once
- [ ] Run new test and it should never fail
