### PR TITLE
Communicate with MongoDB w/ TLS

### DIFF
--- a/lib/models/mongo/mongoose-control.js
+++ b/lib/models/mongo/mongoose-control.js
@@ -24,7 +24,7 @@ mongooseControl.start = function (cb) {
       ssl = {
         ssl: true,
         sslValidate: true,
-        sslCA: ca,
+        sslCA: [ ca ],
         sslKey: key,
         sslCert: cert
       }

--- a/unit/models/mongo/mongoose-control.js
+++ b/unit/models/mongo/mongoose-control.js
@@ -70,7 +70,7 @@ describe('mongoose-control', function () {
               server: {
                 ssl: true,
                 sslValidate: true,
-                sslCA: 'cacert',
+                sslCA: [ 'cacert' ],
                 sslCert: 'cert',
                 sslKey: 'key'
               }


### PR DESCRIPTION
MongoDB now has TLS support, so we are going to connect to it using TLS!
- `mongoose-control` is the only place where `mongoose` is connected
- `mongoose-control` is only called once in the application (outside of tests), so reading the files inline here is fine (right, @anandkumarpatel?)
### Reviewers
- [x] @anandkumarpatel 
- [x] @rsandor
### Tests
- [x] unit test written
- [x] tested on gamma by @bkendall at bc66302
### Integration Test

Please follow the guidelines presented in the [How to Test an API PR](https://github.com/CodeNow/devops-scripts/wiki/How-to-Test-an-API-Pull-Request)
article when setting-up and performing tests.
- [x] Integration Tested @ commitsh by @rsandor on (gamma|epsilon|staging)
