### PR TITLE
SAN-3797 Masterpod Hipache Entries

### DIFF
--- a/lib/models/redis/hosts.js
+++ b/lib/models/redis/hosts.js
@@ -143,6 +143,10 @@ Hosts.prototype.removeHostsForInstance = function (lightEntry, container, cb) {
     log.warn(logData, 'removeHostsForInstance: missing container or container ports')
     return cb()
   }
+  // Don't delete any masterPod redis entries
+  if (lightEntry.masterPod === true) {
+    return cb()
+  }
   var count = createCount(Object.keys(container.ports).length, function (err) {
     if (err) {
       log.trace(put({


### PR DESCRIPTION
- If it's the masterpod don't remove redis entries. This should make it so while things are building we can still navigate to child containers
### Dependencies

None
### Reviewers
- [x] @anandkumarpatel 
- [x] @podviaznikov 
### Integration Test

Please follow the guidelines presented in the [How to Test an API PR](https://github.com/CodeNow/devops-scripts/wiki/How-to-Test-an-API-Pull-Request)
article when setting-up and performing tests.
- [x] Integration Tested @ 07a05b5 by Nathan on (epsilon)
