### PR TITLE
Update RethinkDB Version

### DIFF
--- a/scripts/sourceDockerfiles/rethinkdb
+++ b/scripts/sourceDockerfiles/rethinkdb
@@ -1,2 +1,2 @@
 # Full list of versions available here: https://registry.hub.docker.com/_/rethinkdb/tags/manage/
-FROM rethinkdb:2.0.3
+FROM rethinkdb:2.3.0


### PR DESCRIPTION
Update RethinkDB image. `2.3.0` is a pretty important version update so we should have this in Runnable.

Test
- [x] Test this Dockerfile gets built
