### PR TITLE
only copy if version.dockerHost exist

### DIFF
--- a/lib/models/mongo/context-version.js
+++ b/lib/models/mongo/context-version.js
@@ -189,7 +189,9 @@ ContextVersionSchema.statics.createDeepCopy = function (user, version, cb) {
   version = version.toJSON ? version.toJSON() : version
 
   var newVersion = new ContextVersion(pick(version, copyFields))
-  newVersion.prevDockerHost = version.dockerHost
+  if (version.dockerHost) {
+    newVersion.prevDockerHost = version.dockerHost
+  }
   newVersion.createdBy = {
     github: user.accounts.github.id
   }


### PR DESCRIPTION
- `version.dockerHost` can be undefined, which blows up validation
### Reviewers
- [x] person_1
### Tests
- [x] build non repo container
