### PR TITLE
SAN-4074; Better Resource and Constraint Errors

### DIFF
--- a/lib/models/apis/docker.js
+++ b/lib/models/apis/docker.js
@@ -178,11 +178,10 @@ Docker.prototype._handleCreateContainerError = function (err, opts, cb) {
       err: err,
       tx: true,
       opts: opts
-    }, 'Invalid `opts` argument')
+    }, 'Invalid create container `opts` provided')
     return cb(err)
   }
 
-  // Determine the org id and constraints for the container create
   var org = 'unknown'
   var constraints = 'unknown'
   if (opts.Labels && isString(opts.Labels['com.docker.swarm.constraints'])) {
@@ -192,8 +191,8 @@ Docker.prototype._handleCreateContainerError = function (err, opts, cb) {
       org = match[1]
     }
   }
+  keypather.set(err, 'data.org', org)
 
-  // Setup the logger
   var log = logger.log.child({
     method: '_handleCreateContainerError',
     org: org,
@@ -205,20 +204,11 @@ Docker.prototype._handleCreateContainerError = function (err, opts, cb) {
   })
   log.info('Handling container create error')
 
-  // Determine the type of error we have encountered
   var isConstraintFailure = new RegExp('unable to find a node that satisfies')
     .test(err.message)
   var isResourceFailure = new RegExp('no resources available to schedule')
     .test(err.message)
 
-  // On constraint or resource failure set to critical and report to rollbar.
-  if (isConstraintFailure || isResourceFailure) {
-    keypather.set(err, 'data.level', 'critical')
-    keypather.set(err, 'data.org', org)
-    error.log(err)
-  }
-
-  // Publish datadog messages where applicable
   if (isConstraintFailure) {
     log.error('Unable to find dock for org')
     monitor.event({
@@ -226,6 +216,8 @@ Docker.prototype._handleCreateContainerError = function (err, opts, cb) {
       text: 'Container create options: ' + JSON.stringify(opts),
       alert_type: 'error'
     })
+    keypather.set(err, 'data.level', 'critical')
+    error.log(err)
   }
 
   if (isResourceFailure) {
@@ -235,6 +227,8 @@ Docker.prototype._handleCreateContainerError = function (err, opts, cb) {
       text: 'Container create options: ' + JSON.stringify(opts),
       alert_type: 'error'
     })
+    keypather.set(err, 'data.level', 'error')
+    error.log(err)
   }
 
   cb(err)

--- a/unit/models/apis/docker.js
+++ b/unit/models/apis/docker.js
@@ -214,6 +214,14 @@ describe('docker: ' + moduleName, function () {
       done()
     })
 
+    it('should shortcircut if create options are invalid', function (done) {
+      model._handleCreateContainerError(new Error('wow'), 'neat', function (err) {
+        expect(err).to.equal(err)
+        expect(err.data).to.not.exist()
+        done()
+      })
+    })
+
     it('should alert if there is no dock for an org', function (done) {
       var noNodeErr = new Error(
         'flufzzz' + 'unable to find a node that satisfies' + 'wowowo0092'
@@ -225,7 +233,7 @@ describe('docker: ' + moduleName, function () {
         sinon.assert.calledWith(monitor.event, sinon.match({
           title: sinon.match('Cannot find dock for org: ' + mockOrgId),
           text: sinon.match(/Container create options:/),
-          alert_type: sinon.match(/^error$/)
+          alert_type: sinon.match('error')
         }))
         sinon.assert.calledOnce(error.log)
         sinon.assert.calledWith(error.log, err)
@@ -239,12 +247,12 @@ describe('docker: ' + moduleName, function () {
       )
       model._handleCreateContainerError(resourceErr, mockCreateOpts, function (err) {
         expect(err).to.equal(resourceErr)
-        expect(err.data.level).to.equal('critical')
+        expect(err.data.level).to.equal('error')
         sinon.assert.calledOnce(monitor.event)
         sinon.assert.calledWith(monitor.event, sinon.match({
           title: sinon.match('Out of dock resources for org: ' + mockOrgId),
           text: sinon.match(/Container create options:/),
-          alert_type: sinon.match(/^error$/)
+          alert_type: sinon.match('error')
         }))
         sinon.assert.calledOnce(error.log)
         sinon.assert.calledWith(error.log, err)


### PR DESCRIPTION
- Added `org` and `constraints` as top level data for container create errors
- Refactored the handler method to make it easier to read
- Used new-style logging in the method
### Reviewers
- [x] @podviaznikov 
- [x] @anandkumarpatel 
### Integration Test

Please follow the guidelines presented in the [How to Test an API PR](https://github.com/CodeNow/devops-scripts/wiki/How-to-Test-an-API-Pull-Request)
article when setting-up and performing tests.
- [x] SnoopALoop Tested @ by @rsandor on (gamma|epsilon|staging)
