### PR TITLE
Fix bunyan serialization error for err

### DIFF
--- a/lib/logger/serializer-env.js
+++ b/lib/logger/serializer-env.js
@@ -2,6 +2,7 @@
  * @module lib/logger/envSerializer
  */
 'use strict'
+var clone = require('101/clone')
 var keypather = require('keypather')()
 
 var envSerializer = {


### PR DESCRIPTION
- Change clone to `JSON.stringify(JSON.parse())`

Found this going through staging logs today

```
[2016-04-29T16:04:21.462Z]  INFO: api/10 on 1d47ce65a462 (/api/lib/middlewares/domains.js:43): middlewares/domains res.send (environment=staging, module=lib/middlewares/domains.js)
    branch: 20ca80389b72b7fd2aa196777432ba0d1ab9396f

    --
    commit: HEAD

    --
    tx: {
      "tid": "41172c2e-49e9-4fd5-aaed-55e1e09ad8c3",
      "url": "GET /instances?githubUsername=CodeNow&ignoredFields%5B0%5D=contextVersions%5B0%5D.build.log&ignoredFields%5B1%5D=contextVersion.build.log",
      "reqStart": "2016-04-29T16:03:44.097Z",
      "userGithubUsername": "taylordolan",
      "userGithubId": 7440805,
      "userGithubEmail": "taylordolan@me.com",
      "txTimestamp": "2016-04-29T16:04:21.462Z",
      "txMSFromReqStart": 37365,
      "txMSDelta": 1
    }
bunyan: ERROR: Exception thrown from the "err" Bunyan serializer. This should never happen. This is a bugin that serializer function.
TypeError: Cannot set property headersSent of #<OutgoingMessage> which has only a getter
    at _clone (/api/node_modules/101/node_modules/clone/clone.js:99:16)
    at _clone (/api/node_modules/101/node_modules/clone/clone.js:99:18)
    at _clone (/api/node_modules/101/node_modules/clone/clone.js:99:18)
    at _clone (/api/node_modules/101/node_modules/clone/clone.js:99:18)
    at _clone (/api/node_modules/101/node_modules/clone/clone.js:99:18)
    at _clone (/api/node_modules/101/node_modules/clone/clone.js:99:18)
    at _clone (/api/node_modules/101/node_modules/clone/clone.js:99:18)
    at _clone (/api/node_modules/101/node_modules/clone/clone.js:99:18)
    at _clone (/api/node_modules/101/node_modules/clone/clone.js:99:18)
    at _clone (/api/node_modules/101/node_modules/clone/clone.js:99:18)
    at _clone (/api/node_modules/101/node_modules/clone/clone.js:99:18)
    at _clone (/api/node_modules/101/node_modules/clone/clone.js:99:18)
    at clone (/api/node_modules/101/node_modules/clone/clone.js:105:10)
    at removeEnvFromObject (/api/lib/logger/serializer-env.js:82:15)
    at Object.composed [as err] (/api/node_modules/101/compose.js:18:16)
    at /api/node_modules/bunyan/lib/bunyan.js:872:50
    at Array.forEach (native)
    at Logger._applySerializers (/api/node_modules/bunyan/lib/bunyan.js:864:35)
    at mkRecord (/api/node_modules/bunyan/lib/bunyan.js:992:25)
    at Logger.error (/api/node_modules/bunyan/lib/bunyan.js:1036:19)
    at report (/api/lib/error.js:75:14)
    at logFn (/api/lib/error.js:70:5)
```

The other options to this would be to use lodash's `_.cloneDeep`: [https://github.com/lodash/lodash/issues/602](https://github.com/lodash/lodash/issues/602)
### Reviewers
- [ ] person_1
### Tests
- [x] Test logging error with mongoose model
### Integration Test

Please follow the guidelines presented in the [How to Test an API PR](https://github.com/CodeNow/devops-scripts/wiki/How-to-Test-an-API-Pull-Request)
article when setting-up and performing tests.
- [ ] Integration Tested @ commitsh by person_3 on (gamma|epsilon|staging)
