### PR TITLE
remove `runnable-api-client` from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,20 +174,7 @@ Instances - Running build which consists of running containers for each project 
 This may be because you're getting access denied from npm. Which is trying to clone a private repo (runnable-api-client). Make sure you set up a ssh key with github and ssh-add it. (ssh-add ~/.ssh/github_rsa)
 [Your github ssh keys](https://github.com/settings/ssh)
 
-### Rapid Prototyping with Runnable-Api-Client
-
-If you find yourself working on a feature that constantly involves updating the runnable-api-client, use npm link.
-
-```
-cd <runnable-api-client-path>
-npm link
-cd <runnable-api>
-npm link runnable
-# ... after you've commited some runnable-client changes and updated the version
-npm run client-version # this will update the client's version to the latest in the package.json - remember to commit it.
-```
-
-Models:
+### Models
 
 - A context represents a project context (like redis)
 - A version is a version of a particular context (build files, github commitHash)


### PR DESCRIPTION
Don't mention runnable-api-client
