### PR TITLE
Save usernames before sending events

### DIFF
--- a/lib/routes/instances/index.js
+++ b/lib/routes/instances/index.js
@@ -334,10 +334,13 @@ app.post('/instances/',
   // If the build has completed, but hasn't failed, create the container
   builds.findById('build._id'), // to avoid race with build route!
   instances.model.save(),
+  // If the build hasn't finished yet, this will deploy when it finishes
+  instances.model.populateOwnerAndCreatedBy('sessionUser'),
+  instances.model.populateModels(),
   mw.req('build.successful').validate(validations.equals(true))
     .then(
       function (req, res, next) {
-        // short-circuit: happens when instance was forked and builds was already built successfully
+        // short-circuit: happens when instance was forked and build was already built successfully
         var manual = keypather.get(req, 'contextVersion.build.triggeredAction.manual')
         if (!manual) {
           rabbitMQ.instanceDeployed({
@@ -354,9 +357,6 @@ app.post('/instances/',
         })
         next()
       }),
-  // If the build hasn't finished yet, this will deploy when it finishes
-  instances.model.populateOwnerAndCreatedBy('sessionUser'),
-  instances.model.populateModels(),
   messenger.emitInstanceUpdate('instance', 'post'),
   mw.res.send(201, 'instance'))
 


### PR DESCRIPTION
# Save instance.owner.username before publishing jobs

Right now we publish jobs/events before instance.owner.username is saved in mongo.
This requires writing additional code in the consumers of the events. Like this one https://github.com/CodeNow/pheidi/blob/master/lib/workers/instance.deployed.js#L105
### Reviewers
- [x] @myztiq
- [x] @thejsj
### Integration Test

Please follow the guidelines presented in the [How to Test an API PR](https://github.com/CodeNow/devops-scripts/wiki/How-to-Test-an-API-Pull-Request)
article when setting-up and performing tests.
- [ ] Integration Tested @ commitsh by person_3 on (gamma|epsilon|staging)
