### PR TITLE
Use session user token

### DIFF
--- a/lib/routes/instances/index.js
+++ b/lib/routes/instances/index.js
@@ -192,7 +192,7 @@ app.get('/instances/',
   timers.model.startTimer('githubUsername_check'),
   mw.query('githubUsername').require()
     .then(
-      github.create(),
+      github.create({token: 'sessionUser.accounts.github.accessToken'}),
       github.model.getUserByUsername('query.githubUsername'),
       mw.query().set('owner.github', 'githubResult.id')),
   timers.model.stopTimer('githubUsername_check'),

--- a/lib/routes/settings.js
+++ b/lib/routes/settings.js
@@ -68,7 +68,7 @@ app.get('/settings/',
   mw.query({or: ['owner.github', 'githubUsername']}).require(),
   mw.query('githubUsername').require()
     .then(
-      github.create(),
+      github.create({token: 'sessionUser.accounts.github.accessToken'}),
       github.model.getUserByUsername('query.githubUsername'),
       mw.query().set('owner.github', 'githubResult.id')),
   mw.query('owner').pick(),


### PR DESCRIPTION
# Use session user github token to resolve github user id

We used oauth client id and client secret in 2 cases to resolve github username to the id.
This will use rate-limit for runnable github app. The problem becomes bigger if cache is not working properly. In this change we make call to github using session user github token.
### Reviewers
- [ ] person_1
- [ ] person_2
### Integration Test

Please follow the guidelines presented in the [How to Test an API PR](https://github.com/CodeNow/devops-scripts/wiki/How-to-Test-an-API-Pull-Request)
article when setting-up and performing tests.
- [ ] Integration Tested @ commitsh by person_3 on (gamma|epsilon|staging)
