### PR TITLE
SAN-4439 Toggle IsTesting

### DIFF
--- a/lib/models/services/instance-service.js
+++ b/lib/models/services/instance-service.js
@@ -504,6 +504,7 @@ InstanceService.updateInstance = function (instance, opts, sessionUser) {
     'ipWhitelist',
     'isIsolationGroupMaster',
     'isolated',
+    'isTesting',
     'locked',
     'public'
   ])

--- a/lib/routes/instances/index.js
+++ b/lib/routes/instances/index.js
@@ -116,6 +116,8 @@ var bodyValidations = flow.series(
     mw.body('ipWhitelist').validate(validations.isObject)),
   mw.body('ipWhitelist.enabled').require()
     .then(mw.body('ipWhitelist.enabled').boolean()),
+  mw.body('isTesting').require()
+    .then(mw.body('isTesting').boolean()),
   mw.body('build').require()
     .then(
       mw.body('build').validate(validations.isObjectId),
@@ -263,6 +265,7 @@ app.post('/instances/',
     'ipWhitelist',
     'isIsolationGroupMaster',
     'isolated',
+    'isTesting',
     'masterPod',
     'name',
     'owner',
@@ -394,6 +397,7 @@ app.post('/instances/:id/actions/copy',
     'ipWhitelist',
     'isIsolationGroupMaster',
     'isolated',
+    'isTesting',
     'masterPod',
     'name',
     'owner',


### PR DESCRIPTION
Added isTesting to routes so we can create and update instances with a boolean flag.
### Reviewers
- [x] @thejsj
- [x] @rsandor
### Integration Test

Please follow the guidelines presented in the [How to Test an API PR](https://github.com/CodeNow/devops-scripts/wiki/How-to-Test-an-API-Pull-Request)
article when setting-up and performing tests.
- [x] Integration Tested b4276c8 by @myztiq snoop on epsilon
