### PR TITLE
Check commit sender of committer

### DIFF
--- a/lib/routes/actions/github.js
+++ b/lib/routes/actions/github.js
@@ -58,7 +58,7 @@ app.post('/actions/github/',
         mw.req('instances.length').validate(validations.equals(0))
           // no servers found with this branch check autolaunching
           .then(
-            checkCommitterIsRunnableUser,
+            checkCommitSenderIsRunnableUser,
             instances.findForkableMasterInstances('githubPushInfo.repo', 'githubPushInfo.branch'),
             mw.req('instances.length').validate(validations.equals(0))
               .then(
@@ -163,6 +163,7 @@ function parseGitHubPushData (req, res, next) {
     branch: ref.replace('refs/heads/', ''),
     commit: headCommit.id,
     committer: keypather.get(headCommit, 'committer.username'),
+    commitSender: keypather.get(payload, 'sender.login'),
     commitLog: payload.commits || [],
     user: payload.sender,
     ref: ref
@@ -173,39 +174,39 @@ function parseGitHubPushData (req, res, next) {
 
 module.exports.parseGitHubPushData = parseGitHubPushData
 
-function checkCommitterIsRunnableUser (req, res, next) {
-  var committerUsername = keypather.get(req, 'githubPushInfo.committer')
+function checkCommitSenderIsRunnableUser (req, res, next) {
+  var senderUsername = keypather.get(req, 'githubPushInfo.commitSender')
   var logData = {
     tx: true,
     data: req.githubPushInfo
   }
-  log.info(logData, 'checkCommitterIsRunnableUser')
-  if (!committerUsername) {
-    return res.status(403).send('Commit author/committer username is empty')
+  log.info(logData, 'checkCommitSenderIsRunnableUser')
+  if (!senderUsername) {
+    return res.status(403).send('Commit sender username is empty')
   }
-  User.findOne({ 'accounts.github.username': committerUsername }, function (err, record) {
+  User.findOne({ 'accounts.github.username': senderUsername }, function (err, record) {
     // if committer is not in a Runnable user
     if (err) {
-      log.error(put({ err: err }, logData), 'checkCommitterIsRunnableUser error')
+      log.error(put({ err: err }, logData), 'checkCommitSenderIsRunnableUser error')
       return next(err)
     }
     if (!record) {
-      var committerNotRunnableUserError = Boom.forbidden(
-        'Commit author/committer is not a Runnable user',
+      var commitSenderNotRunnableUserError = Boom.forbidden(
+        'Commit sender is not a Runnable user',
         req.githubPushInfo
       )
       log.error(
-        put({ err: committerNotRunnableUserError }, logData),
-        'checkCommitterIsRunnableUser Commit author/committer is not a Runnable user'
+        put({ err: commitSenderNotRunnableUserError }, logData),
+        'checkCommitSenderIsRunnableUser Commit sender is not a Runnable user'
       )
-      return res.status(403).send('Commit author/committer is not a Runnable user')
+      return res.status(403).send('Commit sender is not a Runnable user')
     }
-    log.trace(logData, 'checkCommitterIsRunnableUser succseful (user is Runnable user)')
+    log.trace(logData, 'checkCommitSenderIsRunnableUser succseful (user is Runnable user)')
     return next()
   })
 }
 
-module.exports.checkCommitterIsRunnableUser = checkCommitterIsRunnableUser
+module.exports.checkCommitSenderIsRunnableUser = checkCommitSenderIsRunnableUser
 
 /**
  * Middleware to check if repo owner org is whitelisted.

--- a/unit/github-actions.js
+++ b/unit/github-actions.js
@@ -185,11 +185,11 @@ describe('GitHub Actions: ' + moduleName, function () {
     })
   })
 
-  describe('checkCommitterIsRunnableUser', function () {
+  describe('checkCommitPusherIsRunnableUser', function () {
     var username = 'thejsj'
     var req = {
       githubPushInfo: {
-        committer: username
+        commitPusher: username
       }
     }
     beforeEach(function (done) {
@@ -204,7 +204,7 @@ describe('GitHub Actions: ' + moduleName, function () {
     it('should next with error if db call failed', function (done) {
       var mongoErr = new Error('Mongo error')
       User.findOne.yieldsAsync(mongoErr)
-      githubActions.checkCommitterIsRunnableUser(req, {}, function (err) {
+      githubActions.checkCommitPusherIsRunnableUser(req, {}, function (err) {
         expect(err).to.equal(mongoErr)
         sinon.assert.calledOnce(User.findOne)
         sinon.assert.calledWith(User.findOne, { 'accounts.github.username': username })
@@ -214,7 +214,7 @@ describe('GitHub Actions: ' + moduleName, function () {
     })
 
     it('should next without error if everything worked', function (done) {
-      githubActions.checkCommitterIsRunnableUser(req, {}, function (err) {
+      githubActions.checkCommitPusherIsRunnableUser(req, {}, function (err) {
         expect(err).to.not.exist()
         sinon.assert.calledOnce(User.findOne)
         sinon.assert.calledWith(User.findOne, { 'accounts.github.username': username })
@@ -237,14 +237,14 @@ describe('GitHub Actions: ' + moduleName, function () {
           return { send: callback.bind(callback, code) }
         }
       }
-      githubActions.checkCommitterIsRunnableUser(req, res, errStub)
+      githubActions.checkCommitPusherIsRunnableUser(req, res, errStub)
     })
 
     it('should respond with 403 if username was not specified', function (done) {
       var errStub = sinon.stub()
       var callback = function (code, message) {
         expect(code).to.equal(403)
-        expect(message).to.match(/Commit author\/committer username is empty/i)
+        expect(message).to.match(/commit.*pusher.*username.*is.*empty/i)
         sinon.assert.notCalled(User.findOne)
         done()
       }
@@ -258,7 +258,7 @@ describe('GitHub Actions: ' + moduleName, function () {
           committer: null
         }
       }
-      githubActions.checkCommitterIsRunnableUser(req, res, errStub)
+      githubActions.checkCommitPusherIsRunnableUser(req, res, errStub)
     })
   })
 })


### PR DESCRIPTION
### What this PR does
- Checks `commiterSender` instead of `commiter`
### Reviewers
- [ ] person_1
- [ ] person_2
### Tests
- [ ] Commit something with user A (not a Runnable user), push it with user B (Runnable user). Should work.
- [ ] Commit something with user B (not a Runnable user), push it with user A (Runnable user). Should work
### Integration Test

Please follow the guidelines presented in the [How to Test an API PR](https://github.com/CodeNow/devops-scripts/wiki/How-to-Test-an-API-Pull-Request)
article when setting-up and performing tests.
- [ ] Integration Tested @ commitsh by person_3 on (gamma|epsilon|staging)
