### PR TITLE
Add create at to user whitelisted

### DIFF
--- a/lib/models/rabbitmq/index.js
+++ b/lib/models/rabbitmq/index.js
@@ -416,7 +416,8 @@ RabbitMQ.prototype.publishUserWhitelisted = function (data) {
   }, 'RabbitMQ.prototype.publishUserWhitelisted')
   var requiredKeys = [
     'githubId',
-    'orgName'
+    'orgName',
+    'createdAt'
   ]
   this._validate(data, requiredKeys, 'publishUserWhitelisted')
   data.createdAt = Math.floor(new Date().getTime() / 1000)

--- a/lib/models/services/whitelist-service.js
+++ b/lib/models/services/whitelist-service.js
@@ -115,7 +115,8 @@ module.exports = {
         }, 'Publish User Whitelisted')
         rabbitMQ.publishUserWhitelisted({
           githubId: org.id.toString(),
-          orgName: org.login
+          orgName: org.login,
+          createdAt: Math.floor(new Date().getTime() / 1000)
         })
       })
       .get('userWhitelist')

--- a/unit/models/services/whitelist-service.js
+++ b/unit/models/services/whitelist-service.js
@@ -184,7 +184,8 @@ describe('auth/whitelist unit test: ', function () {
             rabbitMQ.publishUserWhitelisted,
             {
               githubId: mockGithubOrg.id.toString(),
-              orgName: mockGithubOrg.login
+              orgName: mockGithubOrg.login,
+              createdAt: sinon.match.number
             }
           )
           done()


### PR DESCRIPTION
### What this PR does
- Add  `createAt` to user whitelisted event
### Reviewers
- [x] @Nathan219 
### Tests
- [x] Make sure job gets published correctly
### Integration Test

Please follow the guidelines presented in the [How to Test an API PR](https://github.com/CodeNow/devops-scripts/wiki/How-to-Test-an-API-Pull-Request)
article when setting-up and performing tests.
- [x] Integration Tested @ `4e64c2a47e3fe0184300fb1d1038cfc3e3048261` by `snoop` on `gamma`
