### PR TITLE
Fail worker

### DIFF
--- a/lib/workers/isolation.match-commit.js
+++ b/lib/workers/isolation.match-commit.js
@@ -126,15 +126,25 @@ function MatchCommitInIsolationInstances (job) {
         instances: childInstancesToUpdate.length
       }, 'instances with same commit found')
       return Promise.map(childInstancesToUpdate, function (instance) {
+        var instanceId = instance._id.toString()
         log.trace({
-          instanceId: instance._id.toString()
+          instanceId: instanceId
         }, 'updateInstanceCommitToNewCommit for child instance')
         return InstanceService.updateInstanceCommitToNewCommit(instance, commitHash, sessionUser)
           .catch(function (err) {
             log.warn({
-              instanceId: instance._id.toString(),
+              instanceId: instanceId,
               err: err
             }, 'Failed to updateInstanceCommitToNewCommit for child instance')
+            if (err.isBoom && err.output.statusCode === 404) {
+              throw new TaskFatalError(
+                queueName,
+                'Failed to match commits. Some entities were removed', {
+                  err: err,
+                  instanceId: instanceId
+                }
+              )
+            }
             throw err
           })
       })

--- a/unit/workers/isolation.match-commit.js
+++ b/unit/workers/isolation.match-commit.js
@@ -6,6 +6,7 @@
 var Lab = require('lab')
 var lab = exports.lab = Lab.script()
 
+var Boom = require('dat-middleware').Boom
 var clone = require('101/clone')
 var Code = require('code')
 var sinon = require('sinon')
@@ -177,6 +178,16 @@ describe('isolation.match-commit', function () {
         matchCommitWithIsolationGroupMaster(testJob).asCallback(function (err, res) {
           expect(err).to.exist()
           expect(err).to.deep.equal(testErr)
+          done()
+        })
+      })
+
+      it('should throw fatal error if updateInstanceCommitToNewCommit failed with 404', function (done) {
+        InstanceService.updateInstanceCommitToNewCommit.rejects(Boom.notFound('Context Version not found'))
+        matchCommitWithIsolationGroupMaster(testJob).asCallback(function (err, res) {
+          expect(err).to.exist()
+          expect(err).to.be.an.instanceof(TaskFatalError)
+          expect(err.message).to.equal('isolation.match-commit: Failed to match commits. Some entities were removed')
           done()
         })
       })


### PR DESCRIPTION
If worker get 404 (context version not found) we should fail it fatally. No way to recover from that state.

We still should investigate why context version was deleted in a first place.
### Reviewers
- [x] @Nathan219
- [ ] person_2
### Tests
- [ ] Additional test...
### Integration Test

Please follow the guidelines presented in the [How to Test an API PR](https://github.com/CodeNow/devops-scripts/wiki/How-to-Test-an-API-Pull-Request)
article when setting-up and performing tests.
- [ ] Integration Tested @ commitsh by person_3 on (gamma|epsilon|staging)
