### PR TITLE
Add isManual check to match commit

### DIFF
--- a/lib/models/services/instance-service.js
+++ b/lib/models/services/instance-service.js
@@ -455,7 +455,9 @@ InstanceService._setNewContextVersionOnInstance = function (instance, opts, sess
         })
         .tap(function matchOtherIsolatedCommits () {
           // Match commit only after new ACV has been set
-          if (instance.isolated) {
+          var isManual = keypather.get(instance, 'contextVersion.build.triggeredAction.manual')
+          // Only match commit for isolated instances manually updated
+          if (instance.isolated && isManual) {
             log.trace({
               isolationId: instance.isolated
             }, 'Isolated, enqueing job to match relative isolated instances with same commit')


### PR DESCRIPTION
### What this PR does
- Only match commits for manually triggered builds
### Reviewers
- [x] @podviaznikov 
- [x] @Nathan219 
### Tests
- [x] Make sure match commit works
- [x] Make sure match commit doesn't run when build is manual
### Integration Test

Please follow the guidelines presented in the [How to Test an API PR](https://github.com/CodeNow/devops-scripts/wiki/How-to-Test-an-API-Pull-Request)
article when setting-up and performing tests.
- [x] Integration Tested @ `ae9733b3e1fd29b108f0697b1eb43ded70535d15` by `snoop` on `gamma`
