### PR TITLE
updateInstance takes a string buildId

### DIFF
--- a/lib/workers/instance.rebuild.js
+++ b/lib/workers/instance.rebuild.js
@@ -128,7 +128,7 @@ function InstanceRebuildWorker (job) {
     })
     .then(function (data) {
       log.info({ build: data.build }, 'InstanceRebuildWorker build was build. Update instance')
-      var buildId = keypather.get(data, 'build._id')
+      var buildId = keypather.get(data, 'build._id.toString()')
       var opts = {
         build: buildId
       }


### PR DESCRIPTION
- UpdateInstance takes a buildId as a string, not an objectId.
### Dependencies
- [ ] list dependencies (eg, PR from another branch or repo; tags or versions required prior to deployment)
### Reviewers
- [ ] person_1
- [ ] person_2
### Tests
- [ ] Additional test...
### Integration Test

Please follow the guidelines presented in the [How to Test an API PR](https://github.com/CodeNow/devops-scripts/wiki/How-to-Test-an-API-Pull-Request)
article when setting-up and performing tests.
- [ ] Integration Tested @ commitsh by person_3 on (gamma|epsilon|staging)

not an object
