### PR TITLE
Minor fix logger

### DIFF
--- a/lib/models/apis/docker.js
+++ b/lib/models/apis/docker.js
@@ -919,19 +919,12 @@ Docker.prototype.stopContainer = function (containerId, force, cb) {
  * @param {Function} cb
  */
 Docker.prototype.killContainer = function (containerId, cb) {
-  log = log.child(put({
-    containerId: containerId,
-    method: 'Docker.prototype.killContainer'
-  }, this.logData))
-  log.info('called')
-  this._containerAction(containerId, 'kill', {}, callback)
-  function callback (err) {
-    if (err) {
-      log.error({ err: err }, 'kill callback error')
-      return cb(err)
-    }
-    cb(null)
+  var logData = {
+    tx: true,
+    containerId: containerId
   }
+  log.info(logData, 'Docker.prototype.killContainer')
+  this._containerAction(containerId, 'kill', {}, cb)
 }
 
 function notModifiedError (err) {


### PR DESCRIPTION
We used reassigned `log` without `var`

and that causes logs as this:

```
{"name":"api","branch":"3bbb59a0138c1da6e8efc35152a7d9931f01ee5d\n","commit":"HEAD\n","environment":"production-delta","hostname":"api-worker","pid":15,"tx":{"txTimestamp":"2016-08-05T02:05:40.486Z"},"module":"lib/models/apis/docker.js","containerId":"46bd6e6736b6d24a37623a0d2297cd28f5bf73c4afb7405608bb89997b821d2a","method":"Docker.prototype.killContainer","dockerHost":"http://10.8.4.40:2375","opts":{},"level":30,"msg":"Docker.prototype.startContainer","time":"2016-08-05T02:05:40.486Z","v":0}
```
### Reviewers
- [ ] person_1
