### PR TITLE
update mem res to 4mb because docker 12 broke and does not support 1 …

### DIFF
--- a/lib/models/apis/docker.js
+++ b/lib/models/apis/docker.js
@@ -860,7 +860,7 @@ Docker.prototype.clearContainerMemory = function (containerId, cb) {
   // TODO: set to 0 once docker fixes this
   this._containerAction(containerId, 'update', {
     Memory: 4194304, // 4mb lowest docker supports
-    MemoryReservation: 1 // 1b is lowest you can set
+    MemoryReservation: 4194304 // 4mb is lowest you can set
   }, cb)
 }
 

--- a/unit/models/apis/docker.js
+++ b/unit/models/apis/docker.js
@@ -1108,7 +1108,7 @@ describe('docker: ' + moduleName, function () {
         sinon.assert.calledOnce(model._containerAction)
         sinon.assert.calledWith(model._containerAction, testId, 'update', {
           Memory: 4194304,
-          MemoryReservation: 1
+          MemoryReservation: 4194304
         })
         done()
       })


### PR DESCRIPTION
- update mem res to 4mb because docker 12 broke and does not support anymore
### Reviewers
- [ ] person_1
