### PR TITLE
have isOwner check if user is helloRunnable

### DIFF
--- a/lib/models/services/permission-service.js
+++ b/lib/models/services/permission-service.js
@@ -160,7 +160,7 @@ PermissionService.isOwnerOf = function (sessionUser, model) {
     return Promise.resolve()
   }
   if (userGithubId === process.env.HELLO_RUNNABLE_GITHUB_ID) {
-    return Promise.reject(new Warning('HelloRunnable should always fails org owner checks'))
+    return Promise.reject(new Warning('HelloRunnable should always fail org owner checks'))
   }
   return userService.getByGithubId(userGithubId)
     .then(function (user) {

--- a/unit/models/services/permission-service.js
+++ b/unit/models/services/permission-service.js
@@ -340,7 +340,7 @@ describe('PermissionService', function () {
     it('should reject if sessionUser is helloRunnable', function (done) {
       PermissionService.isOwnerOf(helloRunnable, { owner: { github: '1' } })
         .catch(function (err) {
-          expect(err.message).to.equal('HelloRunnable should always fails org owner checks')
+          expect(err.message).to.equal('HelloRunnable should always fail org owner checks')
           done()
         })
     })


### PR DESCRIPTION
- I added a short-circuit check for helloRunnable in the isOwner check.  This will prevent api from checking big-poppa when the user is HelloRunnable
### Reviewers
- [x] @podviaznikov
- [x] @thejsj
### Tests
- [ ] Make sure everything still works.  This doesn't change any behavior.  HelloRunnable would have fetched it's user, failed to be part of the org, then unsuccessfully attempt to add itself to an org
### Integration Test

Please follow the guidelines presented in the [How to Test an API PR](https://github.com/CodeNow/devops-scripts/wiki/How-to-Test-an-API-Pull-Request)
article when setting-up and performing tests.
- [ ] Integration Tested @ commitsh by person_3 on (gamma|epsilon|staging)
