### PR TITLE
Add new property

### DIFF
--- a/lib/models/mongo/schemas/instance.js
+++ b/lib/models/mongo/schemas/instance.js
@@ -115,11 +115,11 @@ var InstanceSchema = module.exports = new Schema({
     type: Boolean,
     'default': false
   },
-  /** True if instance can be deleted automatically when not used
+  /** True if instance cannot be deleted automatically (e.x. when not used)
    * @type Boolean */
-  allowAutoDeletion: {
+  disableAutoDeletion: {
     type: Boolean,
-    'default': true
+    'default': false
   },
   network: {
     type: {


### PR DESCRIPTION
Needed for https://github.com/CodeNow/khronos/pull/113.

New property is going to be used only by khronos right now.
Khronos will check that property and if it's set instance wouldn't be deleted after 7 days.
This property for now would be set manually in DB for Runnable Failover Test instances.

In the future it would be possible to update this property from UI: so user can lock instance from deletion.
