### PR TITLE
Replaced ensureOwnerOrModerator with ensureModelAccess

### DIFF
--- a/lib/routes/instances/dependencies/index.js
+++ b/lib/routes/instances/dependencies/index.js
@@ -13,7 +13,7 @@ app.all('/instances/:id/dependencies*',
   function (req, res, next) {
     InstanceService.findInstance(req.params.id)
     .tap(function (instance) {
-      return PermissionService.ensureOwnerOrModerator(req.sessionUser, instance)
+      return PermissionService.ensureModelAccess(req.sessionUser, instance)
     })
     .tap(function (instance) {
       req.instance = instance


### PR DESCRIPTION
# Replacing permissions-service method in dependencies route

This replaces a method checking the user against the hello runnable user with another method that calls it later.
