### PR TITLE
Added new property to org metadata flags

### DIFF
--- a/lib/models/services/organization-service.js
+++ b/lib/models/services/organization-service.js
@@ -223,8 +223,9 @@ const OrganizationService = module.exports = {
   ORG_FLAG_SCHEMA: joi.object({
     metadata: joi.object({
       hasAha: joi.boolean(),
-      hasConfirmedSetup: joi.boolean()
-    }).or('hasAha', 'hasConfirmedSetup').required()
+      hasConfirmedSetup: joi.boolean(),
+      hasPersonalRunnabot: joi.boolean()
+    }).or('hasAha', 'hasConfirmedSetup', 'hasPersonalRunnabot').required()
   }).required().label('Organization opts validate'),
 
   /**

--- a/lib/routes/auth/whitelist.js
+++ b/lib/routes/auth/whitelist.js
@@ -78,7 +78,7 @@ app.post('/auth/whitelist',
  */
 module.exports.updateFlags = function (req, res) {
   const bigPoppaId = keypather.get(req, 'params.id')
-  const metadata = pick(keypather.get(req, 'body.metadata'), ['hasConfirmedSetup', 'hasAha'])
+  const metadata = pick(keypather.get(req, 'body.metadata'), ['hasConfirmedSetup', 'hasAha', 'hasPersonalRunnabot'])
   return OrganizationService.updateFlagsOnOrg(bigPoppaId, req.sessionUser, {
     metadata: metadata
   })


### PR DESCRIPTION
### This PR will add the necessary validator for a new property for the api metadata object, hasPersonalRunnabot. This will enable the hasPersonalRunnabot value to be persisted without checking whether runnabot is a collaborator on a github user's repos.