### PR TITLE
Fix for the warning in terminal that happens every time you type

### DIFF
--- a/lib/socket/terminal-stream.js
+++ b/lib/socket/terminal-stream.js
@@ -167,11 +167,16 @@ module.exports._setupStream = function (socket, data) {
       const connection = terminalConnections[terminalId]
       if (connection.bufferStream) {
         // if there is already a bufferStream, remove the listener
-        connection.bufferStream.end()
+        connection.bufferStream.removeListener('data', queueLastMessage)
       }
       const bufferStream = commonStream.connectStream(execStream, clientTermStream, log)
 
       connection.bufferStream = bufferStream
+      if (connection.clientTermStream) {
+        // if there is already a bufferStream, remove the listener
+        connection.clientTermStream.removeListener('data', writeUserDataToTerminal)
+      }
+      connection.clientTermStream = clientTermStream
 
       execStream.once('error', onSocketFailure)
       // reverse the queue, since it's FIFO


### PR DESCRIPTION
Don't call end.  Remove the listener.  Keep the clientTermStream, remove the listener before connecting the new one