### PR TITLE
lock down http-proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "extend": "^1.3.0",
     "github": "git+ssh://git@github.com/podviaznikov/node-github.git#66dc2d069c59585cc166d87472fb22f7573f9ff5",
     "hashids": "^0.3.3",
-    "http-proxy": "^1.14.0",
+    "http-proxy": "1.15.2",
     "i": "^0.3.2",
     "joi": "^9.0.4",
     "json-hash": "0.0.4",


### PR DESCRIPTION
[//]: # (Let's get your best description here about what's happened! Here's a list as well, if you like:)

* lock down http-proxy because 1.16.0 breaks ours
