### PR TITLE
fix DockerComposeClusterService._createSiblingContextVersion args

### DIFF
--- a/lib/models/services/docker-compose-cluster-service.js
+++ b/lib/models/services/docker-compose-cluster-service.js
@@ -278,7 +278,7 @@ module.exports = class DockerComposeClusterService {
 
     return DockerComposeClusterService._createContext(sessionUser, orgInfo)
     .then((context) => {
-      return DockerComposeClusterService._createSiblingContextVersion(sessionUser, context._id, orgInfo, parsedComposeData.contextVersion.buildDockerfilePath, parsedComposeData.files['/Dockerfile'].body)
+      return DockerComposeClusterService._createSiblingContextVersion(sessionUser, context._id, orgInfo, parsedComposeData.files['/Dockerfile'].body)
     })
     .then((contextVersion) => {
       return DockerComposeClusterService._createBuild(sessionUser, contextVersion._id)

--- a/unit/models/services/docker-compose-cluster-service.js
+++ b/unit/models/services/docker-compose-cluster-service.js
@@ -623,7 +623,7 @@ describe('Docker Compose Cluster Service Unit Tests', function () {
         sinon.assert.calledOnce(DockerComposeClusterService._createContext)
         sinon.assert.calledWith(DockerComposeClusterService._createContext, testSessionUser, testOrgInfo)
         sinon.assert.calledOnce(DockerComposeClusterService._createSiblingContextVersion)
-        sinon.assert.calledWith(DockerComposeClusterService._createSiblingContextVersion, testSessionUser, testContext._id, testOrgInfo, testMainParsedContent.contextVersion.buildDockerfilePath)
+        sinon.assert.calledWith(DockerComposeClusterService._createSiblingContextVersion, testSessionUser, testContext._id, testOrgInfo, testMainParsedContent.files['/Dockerfile'].body)
         sinon.assert.calledOnce(DockerComposeClusterService._createBuild)
         sinon.assert.calledWith(DockerComposeClusterService._createBuild, testSessionUser, testContextVersion._id)
         sinon.assert.calledOnce(DockerComposeClusterService._createInstance)


### PR DESCRIPTION
[//]: # (Let's get your best description here about what's happened! Here's a list as well, if you like:)

* fix DockerComposeClusterService._createSiblingContextVersion args

