### PR TITLE
Adding worker for AutoForking

### DIFF
--- a/lib/models/rabbitmq/index.js
+++ b/lib/models/rabbitmq/index.js
@@ -56,6 +56,7 @@ RabbitMQ.prototype.connect = function () {
       'context-version.delete',
       'image.push',
       'instance.delete',
+      'instance.fork',
       'instance.kill',
       'instance.rebuild',
       'instance.restart',
@@ -341,6 +342,10 @@ RabbitMQ.prototype.publishInstanceStarted = function (data) {
 
 RabbitMQ.prototype.publishBuildRequested = function (data) {
   this._publisher.publishEvent('build.requested', data)
+}
+
+RabbitMQ.prototype.forkInstance = function (data) {
+  this._publisher.publishTask('instance.fork', data)
 }
 
 module.exports = new RabbitMQ()

--- a/lib/models/services/instance-fork-service.js
+++ b/lib/models/services/instance-fork-service.js
@@ -8,7 +8,6 @@ const exists = require('101/exists')
 const isObject = require('101/is-object')
 const keypather = require('keypather')()
 const monitorDog = require('monitor-dog')
-const pluck = require('101/pluck')
 const Promise = require('bluebird')
 
 const Context = require('models/mongo/context')
@@ -362,16 +361,16 @@ InstanceForkService.forkNonRepoInstance = function (instance, masterInstanceShor
 
 /**
  * Instance forking functionality.
- * @param {Array<Object>} instances List of Instances to fork.
- * @param {Object} pushInfo GitHub push information.
- * @param {String} pushInfo.repo GitHub Repository.
- * @param {String} pushInfo.branch GitHub Branch.
- * @param {String} pushInfo.commit GitHub Commit.
- * @param {Object} pushInfo.user GitHub User object.
- * @param {Number} pushInfo.user.id GitHub User ID.
- * @returns {Promise} Resolved with an array of new Instances.
+ * @param {Instance} instance         - List of Instances to fork.
+ * @param {Object}   pushInfo         - GitHub push information.
+ * @param {String}   pushInfo.repo    - GitHub Repository.
+ * @param {String}   pushInfo.branch  - GitHub Branch.
+ * @param {String}   pushInfo.commit  - GitHub Commit.
+ * @param {Object}   pushInfo.user    - GitHub User object.
+ * @param {Number}   pushInfo.user.id - GitHub User ID.
+ * @resolves {Instance || Undefined} Newly forked instance (or undefined if autoFork failed)
  */
-InstanceForkService.autoFork = function (instances, pushInfo) {
+InstanceForkService.autoFork = function (instance, pushInfo) {
   var log = InstanceForkService.logger.child({
     method: 'autoFork',
     pushInfo: pushInfo
@@ -379,30 +378,26 @@ InstanceForkService.autoFork = function (instances, pushInfo) {
   log.info('autoforking instances')
   monitorDog.increment('api.instance-fork-service.auto-fork')
   var timer = monitorDog.timer('api.instance-fork-service.auto-fork.timer')
-  return Promise.try(function () {
-    if (!Array.isArray(instances)) {
-      throw new Error('autoFork requires instances to be an array')
-    }
-    log.trace({ instanceIds: instances.map(pluck('_id')) }, 'forking these instances')
-    if (!isObject(pushInfo)) {
-      throw new Error('autoFork requires pushInfo to be provided')
-    }
-  })
-    .then(function () {
-      return Promise.map(instances, function (instance) {
-        return InstanceForkService._forkOne(instance, pushInfo)
-          .catch(function (err) {
-            // log the error and return null
-            var data = {
-              err: err,
-              instance: instance._id,
-              pushInfo: pushInfo
-            }
-            log.error(data, 'autoFork error from _forkOne')
-            return null
-          })
-      })
-      .filter(exists)
+  return Promise
+    .try(function () {
+      log.trace({ instanceId: instance._id }, 'forking these instances')
+      if (!isObject(pushInfo)) {
+        throw new Error('autoFork requires pushInfo to be provided')
+      }
+      return instance
+    })
+    .then(function (instance) {
+      return InstanceForkService._forkOne(instance, pushInfo)
+        .catch(function (err) {
+          // log the error and return null
+          var data = {
+            err: err,
+            instance: instance._id,
+            pushInfo: pushInfo
+          }
+          log.error(data, 'autoFork error from _forkOne')
+          return
+        })
     })
     .catch(function (err) {
       log.error({ err: err }, 'errored during autofork')

--- a/lib/models/services/isolation-service.js
+++ b/lib/models/services/isolation-service.js
@@ -697,60 +697,54 @@ IsolationService.deleteIsolationAndEmitInstanceUpdates = Promise.method(function
     })
 })
 
-IsolationService.autoIsolate = Promise.method(function (newInstances, pushInfo) {
-  const log = this.logger.child({
+IsolationService.autoIsolate = function (newInstance, pushInfo) {
+  var log = this.logger.child({
     method: 'autoIsolate',
-    instances: newInstances.map(pluck('_id')),
+    instances: newInstance._id,
     pushInfo
   })
   log.info('attempting to autoisolate instances')
-  return Promise.each(
-    newInstances,
-    function isolateEachNewInstance (i) {
-      log.debug({ instanceId: i._id }, 'looking for aics')
-      return Instance.findOneAsync({ shortHash: i.parent })
-        .then(function (fullParentInstance) {
-          log.debug({ instanceId: fullParentInstance && fullParentInstance._id }, 'aic found instance')
-          if (!fullParentInstance) { return null }
-          return AutoIsolationConfig.findActiveByInstanceId(fullParentInstance._id)
-        })
-        .then(function (aic) {
-          log.debug({ aic: aic }, 'back from looking for aics')
-          if (!aic) { return }
-          log.trace('autoisolating')
-          const instanceUserGithubId = keypather.get(i, 'createdBy.github')
-          const pushUserGithubId = keypather.get(pushInfo, 'user.id')
-          return Promise.props({
-            // instanceUser is the owner of the instance.
-            instanceUser: User.findByGithubIdAsync(instanceUserGithubId),
-            // pushUser is the user who pushed to GitHub (if we have the user in
-            // our database).
-            pushUser: User.findByGithubIdAsync(pushUserGithubId)
-          })
-            .then(function (result) {
-              const isolationConfig = {
-                master: i._id.toString(),
-                children: aic.requestedDependencies.map(function (d) {
-                  // basically, the next function doesn't like mongo models
-                  if (d.instance) {
-                    const o = { instance: d.instance.toString() }
-                    if (d.matchBranch) { o.matchBranch = d.matchBranch }
-                    return o
-                  }
-                  return pick(d, ['org', 'repo', 'branch'])
-                }),
-                redeployOnKilled: aic.redeployOnKilled || false
+  return Instance.findOneAsync({shortHash: newInstance.parent})
+    .then(function (fullParentInstance) {
+      log.debug({instanceId: fullParentInstance && fullParentInstance._id}, 'aic found instance')
+      if (!fullParentInstance) { return null }
+      return AutoIsolationConfig.findActiveByInstanceId(fullParentInstance._id)
+    })
+    .then(function (aic) {
+      log.debug({ aic: aic }, 'back from looking for aics')
+      if (!aic) { return }
+      log.trace('autoisolating')
+      const instanceUserGithubId = keypather.get(newInstance, 'createdBy.github')
+      const pushUserGithubId = keypather.get(pushInfo, 'user.id')
+      return Promise.props({
+        // instanceUser is the owner of the instance.
+        instanceUser: User.findByGithubIdAsync(instanceUserGithubId),
+        // pushUser is the user who pushed to GitHub (if we have the user in
+        // our database).
+        pushUser: User.findByGithubIdAsync(pushUserGithubId)
+      })
+        .then(function (result) {
+          const isolationConfig = {
+            master: newInstance._id.toString(),
+            children: aic.requestedDependencies.map(function (d) {
+              // basically, the next function doesn't like mongo models
+              if (d.instance) {
+                const o = { instance: d.instance.toString() }
+                if (d.matchBranch) { o.matchBranch = d.matchBranch }
+                return o
               }
-              const sessionUser = result.pushUser || result.instanceUser
-              return IsolationService.createIsolationAndEmitInstanceUpdates(
-                isolationConfig,
-                sessionUser
-              )
-            })
+              return pick(d, ['org', 'repo', 'branch'])
+            }),
+            redeployOnKilled: aic.redeployOnKilled || false
+          }
+          const sessionUser = result.pushUser || result.instanceUser
+          return IsolationService.createIsolationAndEmitInstanceUpdates(
+            isolationConfig,
+            sessionUser
+          )
         })
-    }
-  )
-})
+    })
+}
 
 /**
  * If the master of the isolation is testing instance the whole isolation was created

--- a/lib/models/services/webhook-service.js
+++ b/lib/models/services/webhook-service.js
@@ -102,7 +102,7 @@ WebhookService.autoDeploy = function (instances, githubPushInfo) {
  * means it's MasterPod doesn't have a child instance with this branch, so fork it. Isolated children
  * do not count
  *
- * @param {[String]} autoDeployedInstances - instances with this repo and branch whose
+ * @param {[Instance]} autoDeployedInstances - instances with this repo and branch whose
  *                                              masterPod SHOULD NOT be forked
  * @param {Object}   githubPushInfo        - githook data
  * @param {Object}   githubPushInfo.repo   - name of the repository that was updated

--- a/lib/models/services/webhook-service.js
+++ b/lib/models/services/webhook-service.js
@@ -8,8 +8,6 @@ const Promise = require('bluebird')
 
 const BuildService = require('models/services/build-service')
 const Instance = require('models/mongo/instance')
-const InstanceForkService = require('models/services/instance-fork-service')
-const IsolationService = require('models/services/isolation-service')
 const logger = require('logger')
 const MixPanelModel = require('models/apis/mixpanel')
 const rabbitMQ = require('models/rabbitmq')
@@ -132,15 +130,16 @@ WebhookService.autoFork = function (autoDeployedInstances, githubPushInfo) {
       log.error({ err }, 'error attempting to fetch autoForking candidates')
       throw err
     })
-    .then(function (instances) {
+    .tap(function (instances) {
       if (!instances.length) {
         log.info('autoFork found no instances to fork')
-        return null
       }
-      return InstanceForkService.autoFork(instances, githubPushInfo)
-        .tap(function (newInstances) {
-          return IsolationService.autoIsolate(newInstances, githubPushInfo)
-        })
+    })
+    .each(function (instance) {
+      return rabbitMQ.forkInstance({
+        instance: instance,
+        pushInfo: githubPushInfo
+      })
     })
 }
 

--- a/lib/workers/instance.fork.js
+++ b/lib/workers/instance.fork.js
@@ -1,0 +1,67 @@
+/**
+* Fork instance.
+* @module lib/workers/instance.fork
+*/
+'use strict'
+require('loadenv')()
+
+const Instance = require('models/mongo/instance')
+const InstanceForkService = require('models/services/instance-fork-service')
+const InstanceService = require('models/services/instance-service')
+const IsolationService = require('models/services/isolation-service')
+const joi = require('utils/joi')
+const logger = require('logger')
+const WorkerStopError = require('error-cat/errors/worker-stop-error')
+
+module.exports.jobSchema = joi.object({
+  instance: joi.object({
+    shortHash: joi.string().required()
+  }).unknown().required(),
+  pushInfo: joi.object({
+    repo: joi.string().required(),
+    branch: joi.string().required(),
+    commit: joi.string().required(),
+    user: joi.object({
+      id: joi.number().required()
+    }).required()
+  }).unknown().required()
+}).unknown().required()
+
+module.exports.msTimeout = 10000
+
+module.exports.maxNumRetries = 5
+
+/**
+ * Handle instance.fork command
+ * Flow is following:
+ * 1. find stopping instance if still exists
+ * 2. send `stopping` event to the frontend
+ * 3. call docker kill
+ * @param {Object} job - Job info
+ * @returns {Promise}
+ * @resolve {undefined} this promise will not return anything
+ */
+module.exports.task = (job) => {
+  const log = logger.child({ method: 'Instance Fork' })
+  return InstanceService.findInstance(job.instance.shortHash)
+    .catch(Instance.NotFoundError, function (err) {
+      throw new WorkerStopError('Instance not found', {
+        err,
+        job
+      })
+    })
+    .then(function (instance) {
+      return InstanceForkService.autoFork(instance, job.pushInfo)
+    })
+    .tap(function (newInstance) {
+      return IsolationService.autoIsolate(newInstance, job.pushInfo)
+    })
+    .then(function (newInstance) {
+      if (newInstance) {
+        log.info('Successfully forked instance', {
+          originalInstance: job.instance.shortHash,
+          instance: newInstance
+        })
+      }
+    })
+}

--- a/unit/models/services/isolation-service.js
+++ b/unit/models/services/isolation-service.js
@@ -1628,7 +1628,6 @@ describe('Isolation Services Model', function () {
       parent: 'parentId',
       createdBy: { github: 1 }
     }
-    var newInstances = [ mockInstance ]
     var mockAIC = { requestedDependencies: [] }
     var mockInstanceUser = { user: 1 }
     var mockPushUser = { user: 2 }
@@ -1653,7 +1652,7 @@ describe('Isolation Services Model', function () {
     })
 
     it('should find each instance', function (done) {
-      IsolationService.autoIsolate(newInstances, pushInfo)
+      IsolationService.autoIsolate(mockInstance, pushInfo)
         .asCallback(function (err) {
           expect(err).to.not.exist()
           sinon.assert.calledOnce(Instance.findOne)
@@ -1667,7 +1666,7 @@ describe('Isolation Services Model', function () {
     })
 
     it('should look for auto isolation config', function (done) {
-      IsolationService.autoIsolate(newInstances, pushInfo)
+      IsolationService.autoIsolate(mockInstance, pushInfo)
         .asCallback(function (err) {
           expect(err).to.not.exist()
           sinon.assert.calledOnce(AutoIsolationConfig.findActiveByInstanceId)
@@ -1679,7 +1678,7 @@ describe('Isolation Services Model', function () {
     })
 
     it('should find a user from the instance', function (done) {
-      IsolationService.autoIsolate(newInstances, pushInfo)
+      IsolationService.autoIsolate(mockInstance, pushInfo)
         .asCallback(function (err) {
           expect(err).to.not.exist()
           sinon.assert.calledTwice(User.findByGithubId)
@@ -1693,7 +1692,7 @@ describe('Isolation Services Model', function () {
     })
 
     it('should find a user from the push info', function (done) {
-      IsolationService.autoIsolate(newInstances, pushInfo)
+      IsolationService.autoIsolate(mockInstance, pushInfo)
         .asCallback(function (err) {
           expect(err).to.not.exist()
           sinon.assert.calledTwice(User.findByGithubId)
@@ -1707,7 +1706,7 @@ describe('Isolation Services Model', function () {
     })
 
     it('should find a user from the push info', function (done) {
-      IsolationService.autoIsolate(newInstances, pushInfo)
+      IsolationService.autoIsolate(mockInstance, pushInfo)
       .asCallback(function (err) {
         expect(err).to.not.exist()
         sinon.assert.calledOnce(IsolationService.createIsolationAndEmitInstanceUpdates)
@@ -1732,7 +1731,7 @@ describe('Isolation Services Model', function () {
       var mockAIC = { requestedDependencies: [ child ] }
       AutoIsolationConfig.findActiveByInstanceId.resolves(mockAIC)
 
-      IsolationService.autoIsolate(newInstances, pushInfo)
+      IsolationService.autoIsolate(mockInstance, pushInfo)
       .asCallback(function (err) {
         expect(err).to.not.exist()
         sinon.assert.calledOnce(IsolationService.createIsolationAndEmitInstanceUpdates)
@@ -1755,7 +1754,7 @@ describe('Isolation Services Model', function () {
     it('should copy over redeployOnKilled flag', function (done) {
       mockAIC.redeployOnKilled = true
       AutoIsolationConfig.findActiveByInstanceId.resolves(mockAIC)
-      IsolationService.autoIsolate(newInstances, pushInfo)
+      IsolationService.autoIsolate(mockInstance, pushInfo)
         .asCallback(function (err) {
           expect(err).to.not.exist()
           sinon.assert.calledOnce(IsolationService.createIsolationAndEmitInstanceUpdates)

--- a/unit/workers/instance.fork.js
+++ b/unit/workers/instance.fork.js
@@ -1,0 +1,121 @@
+/**
+ * @module unit/workers/instance.fork
+ */
+'use strict'
+const Code = require('code')
+const Lab = require('lab')
+const sinon = require('sinon')
+const WorkerStopError = require('error-cat/errors/worker-stop-error')
+
+const Instance = require('models/mongo/instance')
+const InstanceService = require('models/services/instance-service')
+const InstanceForkService = require('models/services/instance-fork-service')
+const IsolationService = require('models/services/isolation-service')
+const Worker = require('workers/instance.fork')
+
+require('sinon-as-promised')(require('bluebird'))
+const lab = exports.lab = Lab.script()
+
+const afterEach = lab.afterEach
+const beforeEach = lab.beforeEach
+const describe = lab.describe
+const expect = Code.expect
+const it = lab.it
+
+const testInstanceId = '5633e9273e2b5b0c0077fd41'
+const dockerContainer = '46080d6253c8db55b8bbb9408654896964b86c63e863f1b3b0301057d1ad92ba'
+describe('Workers: Instance Fork', function () {
+  let testInstance
+  let pushInfo
+  let testData = {}
+  describe('task', function () {
+    testInstance = new Instance({
+      _id: testInstanceId,
+      name: 'name1',
+      shortHash: 'asd51a1',
+      masterPod: true,
+      owner: {
+        github: 124,
+        username: 'codenow',
+        gravatar: ''
+      },
+      createdBy: {
+        github: 125,
+        username: 'runnabear',
+        gravatar: ''
+      },
+      container: {
+        dockerContainer: dockerContainer
+      },
+      network: {
+        hostIp: '0.0.0.0'
+      },
+      build: '507f191e810c19729de860e2',
+      contextVersion: {
+        appCodeVersions: [
+          {
+            lowerBranch: 'develop',
+            additionalRepo: false
+          }
+        ]
+      }
+    })
+    pushInfo = { user: { id: 2 } }
+    testData = {
+      instance: testInstance,
+      pushInfo: pushInfo
+    }
+
+    beforeEach(function (done) {
+      sinon.stub(InstanceService, 'findInstance').resolves(testInstance)
+      sinon.stub(InstanceForkService, 'autoFork').resolves(testInstance)
+      sinon.stub(IsolationService, 'autoIsolate').resolves(testInstance)
+      done()
+    })
+
+    afterEach(function (done) {
+      InstanceService.findInstance.restore()
+      InstanceForkService.autoFork.restore()
+      IsolationService.autoIsolate.restore()
+      done()
+    })
+
+    it('should fail fatally if findInstance threw no instance error', function (done) {
+      InstanceService.findInstance.rejects(new Instance.NotFoundError('Hey'))
+      Worker.task(testData).asCallback(function (err) {
+        expect(err).to.exist()
+        expect(err).to.be.instanceOf(WorkerStopError)
+        expect(err.message).to.equal('Instance not found')
+        done()
+      })
+    })
+
+    it('should fetch the instance by the shortHash', function (done) {
+      Worker.task(testData).asCallback(function (err) {
+        expect(err).to.not.exist()
+        sinon.assert.calledOnce(InstanceService.findInstance)
+        sinon.assert.calledWith(InstanceService.findInstance, testInstance.shortHash)
+        done()
+      })
+    })
+
+    it('should fork the instance the instance found', function (done) {
+      Worker.task(testData).asCallback(function (err) {
+        expect(err).to.not.exist()
+        sinon.assert.calledOnce(InstanceForkService.autoFork)
+        sinon.assert.calledWith(InstanceForkService.autoFork, testInstance, pushInfo)
+        done()
+      })
+    })
+    it('should isolate the forked instance', function (done) {
+      const forkedInstance = {}
+      InstanceForkService.autoFork.resolves(forkedInstance)
+      Worker.task(testData).asCallback(function (err) {
+        expect(err).to.not.exist()
+        sinon.assert.calledOnce(IsolationService.autoIsolate)
+        sinon.assert.calledWith(IsolationService.autoIsolate, forkedInstance, pushInfo)
+        done()
+      })
+    })
+  })
+})


### PR DESCRIPTION
adding new internal job for autoforking.  This job is created by the webhook service

Moving autoFork from a synchronous job to a worker.  This will allow us to schedule it after other things, like docker compose stuff