### PR TITLE
SAN-5678 - Mitigate spinup delay

### DIFF
--- a/lib/workers/docker.events-stream.connected.js
+++ b/lib/workers/docker.events-stream.connected.js
@@ -41,7 +41,7 @@ module.exports.task = (job) => {
     // Schedule a container create on the first dock
     const dockerClient = new Docker()
     return dockerClient.createContainerAsync({
-      Image: 'node',
+      Image: 'runnable/redis:3.2',
       labels: {
         'com.docker.swarm.constraints': `["org==${org.id}"]`
       }


### PR DESCRIPTION
Mitigate the first dock spinup delay that swarm has. We need to schedule a container to be created first and it'll make subsequent updates work faster.