### PR TITLE
Don't report Invalid Hostname errors

### DIFF
--- a/lib/models/redis/hosts.js
+++ b/lib/models/redis/hosts.js
@@ -5,6 +5,7 @@
 
 const Boom = require('dat-middleware').Boom
 const Promise = require('bluebird')
+const keypather = require('keypather')()
 
 const logger = require('middlewares/logger')(__filename)
 
@@ -37,6 +38,7 @@ function invalidHostname (hostname, msg, cb) {
     errorMsg: msg,
     errorHostname: hostname
   })
+  keypather.set(err, 'data.report', false)
   cb(err)
 }
 


### PR DESCRIPTION
set data.report to false so we don't report this to Rollbar