### PR TITLE
Fix tests by adding new argument

### DIFF
--- a/unit/models/services/cluster-config-service.js
+++ b/unit/models/services/cluster-config-service.js
@@ -2250,14 +2250,14 @@ describe('Cluster Config Service Unit Tests', function () {
 
     it('should not fetch any files if `envFiles` is empty', () => {
       parseResult.envFiles = []
-      return ClusterConfigService.parseComposeFileAndPopulateENVs(composeFileData, repoFullName, mainInstanceName, bigPoppaUser)
+      return ClusterConfigService.parseComposeFileAndPopulateENVs(composeFileData, repoFullName, mainInstanceName, bigPoppaUser, envFiles[0])
         .then(result => {
           sinon.assert.notCalled(ClusterConfigService.fetchFileFromGithub)
         })
     })
 
     it('should fetch all files in `envFiles`', () => {
-      return ClusterConfigService.parseComposeFileAndPopulateENVs(composeFileData, repoFullName, mainInstanceName, bigPoppaUser)
+      return ClusterConfigService.parseComposeFileAndPopulateENVs(composeFileData, repoFullName, mainInstanceName, bigPoppaUser, envFiles[0])
         .then(result => {
           sinon.assert.called(ClusterConfigService.fetchFileFromGithub)
           sinon.assert.callCount(ClusterConfigService.fetchFileFromGithub, envFiles.length)
@@ -2286,7 +2286,7 @@ describe('Cluster Config Service Unit Tests', function () {
     })
 
     it('should call `populateENVsFromFiles`', () => {
-      return ClusterConfigService.parseComposeFileAndPopulateENVs(composeFileData, repoFullName, mainInstanceName, bigPoppaUser)
+      return ClusterConfigService.parseComposeFileAndPopulateENVs(composeFileData, repoFullName, mainInstanceName, bigPoppaUser, envFiles[0])
         .then(result => {
           sinon.assert.calledOnce(octobear.populateENVsFromFiles)
           sinon.assert.calledWithExactly(
@@ -2302,7 +2302,7 @@ describe('Cluster Config Service Unit Tests', function () {
     })
 
     it('should return an object with `.results`', () => {
-      return ClusterConfigService.parseComposeFileAndPopulateENVs(composeFileData, repoFullName, mainInstanceName, bigPoppaUser)
+      return ClusterConfigService.parseComposeFileAndPopulateENVs(composeFileData, repoFullName, mainInstanceName, bigPoppaUser, envFiles[0])
         .then(res => {
           expect(res.results).to.be.an.array()
           expect(res.results).to.equal(parseResult.results)


### PR DESCRIPTION
This fixes tests that are currently broken on master by adding an argument to the ClusterConfigService.parseComposeFileAndPopulateENVs method