### PR TITLE
Update ENV regex to allow for  in the key.

### DIFF
--- a/lib/models/services/instance-service.js
+++ b/lib/models/services/instance-service.js
@@ -32,7 +32,7 @@ const ClusterDataService = require('models/services/cluster-data-service')
 const rabbitMQ = require('models/rabbitmq')
 const User = require('models/mongo/user')
 
-const ENV_REGEX = /^([A-z]+[A-z0-9_]*)=.*$/
+const ENV_REGEX = /^([A-z]+[A-z0-9_\.\-]*)=.*$/
 
 function InstanceService () {}
 


### PR DESCRIPTION
This is to allow for env variables used in ElasticSearch containers. They seem to violate the rules for proper ENV VAR characters allowed.
