### PR TITLE
Update octobear version for url hotfix.

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -283,9 +283,9 @@
       }
     },
     "@runnable/octobear": {
-      "version": "4.0.0",
-      "from": "@runnable/octobear@4.0.0",
-      "resolved": "https://registry.npmjs.org/@runnable/octobear/-/octobear-4.0.0.tgz",
+      "version": "4.0.1",
+      "from": "@runnable/octobear@latest",
+      "resolved": "https://registry.npmjs.org/@runnable/octobear/-/octobear-4.0.1.tgz",
       "dependencies": {
         "dotenv": {
           "version": "4.0.0",
@@ -4249,6 +4249,11 @@
       "version": "3.0.0",
       "from": "lodash.toplainobject@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz"
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "from": "lodash.uniq@>=4.5.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz"
     },
     "lolex": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@runnable/big-poppa-client": "^0.5.1",
     "@runnable/clio-client": "^1.0.8",
     "@runnable/hostname": "^3.0.0",
-    "@runnable/octobear": "^4.0.0",
+    "@runnable/octobear": "^4.0.1",
     "JSONStream": "0.10.x",
     "array-subtract": "^2.0.0",
     "async": "^0.9.0",


### PR DESCRIPTION
* Updated octobear to respect existing ENV VAR URLs

### Dependencies
- [x] https://github.com/Runnable/octobear/pull/21

### Integration Test
- [ ] Integration Tested @ 15484a8 by @tosih on _gamma_ 
`Attempted, but the application is failing used by snoop`
