### PR TITLE
Don't stop emitting cv.deleted if cv is missing container

### DIFF
--- a/lib/models/rabbitmq/index.js
+++ b/lib/models/rabbitmq/index.js
@@ -139,7 +139,7 @@ RabbitMQ.prototype.connect = function () {
       jobSchema: joi.object({
         contextVersion: joi.object({
           build: joi.object({
-            dockerContainer: joi.string().required()
+            dockerContainer: joi.string()
           }).unknown().required(),
           dockerHost: joi.string().uri({ scheme: 'http' }).required()
         }).unknown().required()


### PR DESCRIPTION
Don't stop deleting a CV if it doesn't have a container!
https://rollbar.com/Runnable-2/api-workers/items/4923/